### PR TITLE
GORA-332 fix record.vm template to generate deepCopyToReadOnlyBuffer methos

### DIFF
--- a/gora-compiler/src/main/velocity/org/apache/gora/compiler/templates/record.vm
+++ b/gora-compiler/src/main/velocity/org/apache/gora/compiler/templates/record.vm
@@ -172,7 +172,7 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
     return new #if ($schema.getNamespace())$schema.getNamespace().#end${this.mangle($schema.getName())}.Builder(other);
   }
   
-  private static java.nio.ByteBuffer deepCopyToWriteOnlyBuffer(
+  private static java.nio.ByteBuffer deepCopyToReadOnlyBuffer(
       java.nio.ByteBuffer input) {
     java.nio.ByteBuffer copy = java.nio.ByteBuffer.allocate(input.capacity());
     int position = input.position();


### PR DESCRIPTION
_deepCopyToReadOnlyBuffer_ is expected by generate java code from
schema which use a **bytes** field type.
