### PR TITLE
GORA-341 - Switch gora-orm references to gora-otd in tutorial files

### DIFF
--- a/gora-accumulo/src/test/resources/gora-accumulo-mapping.xml
+++ b/gora-accumulo/src/test/resources/gora-accumulo-mapping.xml
@@ -17,7 +17,7 @@
    limitations under the License.
 -->
 
-<gora-orm>
+<gora-otd>
   <table name="AccessLog">
     <config key="table.file.compress.blocksize" value="32K"/>
   </table>
@@ -54,4 +54,4 @@
   <class name="org.apache.gora.examples.generated.TokenDatum" keyClass="java.lang.String">
     <field name="count" family="common" qualifier="count"/>
   </class>  
-</gora-orm>  
+</gora-otd>

--- a/gora-cassandra/src/test/conf/gora-cassandra-mapping.xml
+++ b/gora-cassandra/src/test/conf/gora-cassandra-mapping.xml
@@ -17,7 +17,7 @@
    limitations under the License.
 -->
 
-<gora-orm>
+<gora-otd>
   <keyspace name="Employee" host="localhost" cluster="Gora Cassandra Test Cluster">
     <family name="p" gc_grace_seconds="5"/>
      <family name="sc" type="super" />
@@ -55,4 +55,4 @@
     <field name="count"  family="p" qualifier="common:count" ttl="10"/>
   </class>
 
-</gora-orm>
+</gora-otd>

--- a/gora-dynamodb/src/test/conf/gora-dynamodb-mapping.xml
+++ b/gora-dynamodb/src/test/conf/gora-dynamodb-mapping.xml
@@ -17,7 +17,7 @@
    limitations under the License.
 -->
 
-<gora-orm>
+<gora-otd>
 
   <table name="person" readcunit="5" writecunit="5"> <!-- optional descriptors for tables -->
   	<key name="ssn" type="hash" att-type="S"/>
@@ -36,4 +36,4 @@
     <attribute name="outlinks" type="S"/>
   </table>
   
-</gora-orm>
+</gora-otd>

--- a/gora-hbase/src/test/conf/gora-hbase-mapping.xml
+++ b/gora-hbase/src/test/conf/gora-hbase-mapping.xml
@@ -17,7 +17,7 @@
    limitations under the License.
 -->
 
-<gora-orm>
+<gora-otd>
 
   <table name="Employee"> <!-- optional descriptors for tables -->
     <family name="info"/> <!-- This can also have params like compression, bloom filters -->
@@ -53,4 +53,4 @@
     <field name="count" family="common" qualifier="count"/>
   </class>
 
-</gora-orm>
+</gora-otd>

--- a/gora-mongodb/src/test/conf/gora-mongodb-mapping.xml
+++ b/gora-mongodb/src/test/conf/gora-mongodb-mapping.xml
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<gora-orm>
+<gora-otd>
 
     <class name="org.apache.gora.examples.generated.Employee" keyClass="java.lang.String" document="frontier">
         <field name="name" docfield="name" type="string"/>
@@ -40,4 +40,4 @@
     </class>
 
 
-</gora-orm>
+</gora-otd>

--- a/gora-mongodb/src/test/conf/multimapping.xml
+++ b/gora-mongodb/src/test/conf/multimapping.xml
@@ -15,7 +15,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<gora-orm>
+<gora-otd>
 
     <class document="frontier" keyClass="java.lang.String" name="org.apache.gora.examples.generated.WebPage">
         <field name="baseUrl" docfield="baseUrl" type="string"/>
@@ -48,4 +48,4 @@
         <field name="inlinks" docfield="links.in" type="document"/>
     </class>
 
-</gora-orm>
+</gora-otd>

--- a/gora-solr/src/test/conf/gora-solr-mapping.xml
+++ b/gora-solr/src/test/conf/gora-solr-mapping.xml
@@ -16,7 +16,7 @@
    limitations under the License.
 -->
 
-<gora-orm>
+<gora-otd>
   <class name="org.apache.gora.examples.generated.Employee" keyClass="java.lang.String" table="Employee">
     <primarykey column="ssn"/>
     <field name="name" column="name"/>
@@ -34,5 +34,5 @@
     <field name="headers" column="headers"/>     
     <field name="metadata" column="metadata"/>
   </class>
-</gora-orm>
+</gora-otd>
 

--- a/gora-sql/src/test/conf/gora-sql-mapping.xml
+++ b/gora-sql/src/test/conf/gora-sql-mapping.xml
@@ -16,7 +16,7 @@
    limitations under the License.
 -->
 
-<gora-orm>
+<gora-otd>
   <class name="org.apache.gora.examples.generated.Employee" keyClass="java.lang.String" table="Employee">
     <primarykey column="id" length="16"/>
     <field name="name" column="name" length="128"/>
@@ -44,5 +44,5 @@
   </fields>
 </table>
 -->
-</gora-orm>
+</gora-otd>
 

--- a/gora-tutorial/conf/gora-cassandra-mapping.xml
+++ b/gora-tutorial/conf/gora-cassandra-mapping.xml
@@ -19,7 +19,7 @@
 <!--
   Gora Mapping file for Cassandra Backend
 -->
-<gora-orm>
+<gora-otd>
 
   <keyspace name="Pageview" cluster="Test Cluster" host="localhost">
     <family name="common"/>
@@ -48,4 +48,4 @@
     <field name="metric" family="common" qualifier="metric"/>
   </class>
 
-</gora-orm>
+</gora-otd>

--- a/gora-tutorial/conf/gora-hbase-mapping.xml
+++ b/gora-tutorial/conf/gora-hbase-mapping.xml
@@ -19,7 +19,7 @@
 <!--
   Gora Mapping file for HBase Backend
 -->
-<gora-orm>
+<gora-otd>
   <table name="Pageview"> <!-- optional descriptors for tables -->
     <family name="common"/> <!-- This can also have params like compression, bloom filters -->
     <family name="http"/>
@@ -43,4 +43,4 @@
     <field name="metric" family="common" qualifier="metric"/>
   </class>
 
-</gora-orm>
+</gora-otd>

--- a/gora-tutorial/conf/gora-solr-mapping.xml
+++ b/gora-tutorial/conf/gora-solr-mapping.xml
@@ -19,7 +19,7 @@
 <!-- 
   Gora Mapping file for SQL Backend
 -->
-<gora-orm>
+<gora-otd>
   <class name="org.apache.gora.tutorial.log.generated.Pageview" keyClass="java.lang.Long" table="AccessLog">
     <primarykey column="line"/>
     <field name="url" column="url"/>
@@ -39,5 +39,5 @@
     <field name="metric" column="metric"/>
   </class>
 
-</gora-orm>
+</gora-otd>
 

--- a/gora-tutorial/conf/gora-sql-mapping.xml
+++ b/gora-tutorial/conf/gora-sql-mapping.xml
@@ -19,7 +19,7 @@
 <!-- 
   Gora Mapping file for SQL Backend
 -->
-<gora-orm>
+<gora-otd>
   <class name="org.apache.gora.tutorial.log.generated.Pageview" keyClass="java.lang.Long" table="AccessLog">
     <primarykey column="line"/>
     <field name="url" column="url" length="512" primarykey="true"/>
@@ -39,5 +39,5 @@
     <field name="metric" column="metric"/>
   </class>
 
-</gora-orm>
+</gora-otd>
 


### PR DESCRIPTION
- Switch the gora-orm element references to gora-otd in the tutorial mapping files to fall more in line with the documentation's use of OTD.
