### PR TITLE
Updated jdom to 1.1.3 to eliminate xerces version conflict.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
     <!-- Misc Dependencies -->
     <guava.version>13.0</guava.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <jdom.version>1.1.2</jdom.version>
+    <jdom.version>1.1.3</jdom.version>
     <hsqldb.version>2.2.8</hsqldb.version>
     <mysql.version>5.1.18</mysql.version>
     <xerces.version>2.9.1</xerces.version>
@@ -1292,11 +1292,11 @@
         <artifactId>mysql-connector-java</artifactId> <version>${mysql.version}</version> 
         </dependency -->
 
-      <dependency>
+      <!--dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>${xerces.version}</version>
-      </dependency>
+      </dependency -->
 
       <!-- Logging Dependencies -->
       <dependency>


### PR DESCRIPTION
This change fixes xerces:xercesImpl version conflict described at:
https://issues.apache.org/jira/browse/GORA-371
