### PR TITLE
NUTCH-1946: Added transitive dep to hbase-common-0.98.8-hadoop2.jar

### DIFF
--- a/gora-hbase/pom.xml
+++ b/gora-hbase/pom.xml
@@ -117,6 +117,18 @@
 
     <dependency>
       <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
       <scope>compile</scope>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -896,6 +896,38 @@
         </exclusions>
       </dependency>
 
+      <!-- HBase Dependencies -->
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-common</artifactId>
+        <version>${hbase.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>avro</artifactId>
+          </exclusion>
+			<exclusion>
+				<artifactId>slf4j-log4j12</artifactId>
+				<groupId>org.slf4j</groupId>
+			</exclusion>
+			<exclusion>
+				<artifactId>hadoop-common</artifactId>
+				<groupId>org.apache.hadoop</groupId>
+			</exclusion>
+			<exclusion>
+				<artifactId>hadoop-yarn-common</artifactId>
+				<groupId>org.apache.hadoop</groupId>
+			</exclusion>
+			<exclusion>
+				<artifactId>hadoop-mapreduce-client-core</artifactId>
+				<groupId>org.apache.hadoop</groupId>
+			</exclusion>
+			<exclusion>
+				<artifactId>hadoop-auth</artifactId>
+				<groupId>org.apache.hadoop</groupId>
+			</exclusion>
+        </exclusions>
+      </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -906,26 +906,26 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>avro</artifactId>
           </exclusion>
-			<exclusion>
-				<artifactId>slf4j-log4j12</artifactId>
-				<groupId>org.slf4j</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-common</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-yarn-common</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-mapreduce-client-core</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-auth</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
+		  <exclusion>
+			<artifactId>slf4j-log4j12</artifactId>
+			<groupId>org.slf4j</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-common</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-yarn-common</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-mapreduce-client-core</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-auth</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -937,26 +937,26 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>avro</artifactId>
           </exclusion>
-			<exclusion>
-				<artifactId>slf4j-log4j12</artifactId>
-				<groupId>org.slf4j</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-common</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-yarn-common</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-mapreduce-client-core</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-auth</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
+		  <exclusion>
+			<artifactId>slf4j-log4j12</artifactId>
+			<groupId>org.slf4j</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-common</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-yarn-common</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-mapreduce-client-core</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-auth</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -969,26 +969,26 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>avro</artifactId>
           </exclusion>
-			<exclusion>
-				<artifactId>slf4j-log4j12</artifactId>
-				<groupId>org.slf4j</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-common</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-yarn-common</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-mapreduce-client-core</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
-			<exclusion>
-				<artifactId>hadoop-auth</artifactId>
-				<groupId>org.apache.hadoop</groupId>
-			</exclusion>
+		  <exclusion>
+			<artifactId>slf4j-log4j12</artifactId>
+			<groupId>org.slf4j</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-common</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-yarn-common</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+			<artifactId>hadoop-mapreduce-client-core</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
+		  <exclusion>
+		    <artifactId>hadoop-auth</artifactId>
+			<groupId>org.apache.hadoop</groupId>
+		  </exclusion>
         </exclusions>
       </dependency>
 


### PR DESCRIPTION
The comment says it all. I used the same exclusion pattern as with hbase-client, given my unfamiliarity with the project, someone else might want to skim over that.