### PR TITLE
GORA-420:  AccumuloStore.createSchema fails when table already exists

### DIFF
--- a/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
+++ b/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
@@ -368,7 +368,7 @@ public class AccumuloStore<K,T extends PersistentBase> extends DataStoreBase<K,T
         }
         credentials = CredentialHelper.create(user, token, conn.getInstance().getInstanceID());
 
-        if (autoCreateSchema)
+        if (autoCreateSchema && !schemaExists())
           createSchema();
       } catch (AccumuloException e) {
         throw new IOException(e);


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/GORA-420