### PR TITLE
GORA-423: Return null for null field value

### DIFF
--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/utils/BSONDecorator.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/utils/BSONDecorator.java
@@ -30,7 +30,7 @@ import com.mongodb.DBObject;
 /**
  * Utility class to build {@link DBObject} used by MongoDB in an easy way by
  * directly specifying the fully qualified names of fields.
- * 
+ *
  * @author Fabien Poulard <fpoulard@dictanova.com>
  */
 public class BSONDecorator {
@@ -43,7 +43,7 @@ public class BSONDecorator {
 
   /**
    * Access the decorated {@link BSONObject}.
-   * 
+   *
    * @return the decorated {@link DBObject} in its actual state
    */
   public DBObject asDBObject() {
@@ -54,7 +54,7 @@ public class BSONDecorator {
    * Check if the field passed in parameter exists or not. The field is passed
    * as a fully qualified name that is the path to the field from the root of
    * the document (for example: "field1" or "parent.child.field2").
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field
    * @return true if the field and all its parents exists in the decorated
@@ -80,7 +80,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a {@link BasicDBObject}.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a {@link BasicDBObject}
@@ -92,7 +92,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a {@link BasicDBList}.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a {@link BasicDBList}
@@ -103,7 +103,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a boolean.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a boolean
@@ -115,7 +115,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a double.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a double
@@ -127,7 +127,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a int.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a double
@@ -139,7 +139,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a long.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a double
@@ -151,7 +151,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a date.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a date
@@ -163,7 +163,7 @@ public class BSONDecorator {
 
   /**
    * Access field as a Utf8 string.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field as a {@link Utf8} string
@@ -171,15 +171,12 @@ public class BSONDecorator {
   public Utf8 getUtf8String(String fieldName) {
     BasicDBObject parent = getFieldParent(fieldName);
     String value = parent.getString(getLeafName(fieldName));
-    if (value != null)
-      return new Utf8(value);
-    else
-      return new Utf8();
+    return (value != null) ? new Utf8(value) : null;
   }
 
   /**
    * Access field as bytes.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field
@@ -196,7 +193,7 @@ public class BSONDecorator {
 
   /**
    * Access field as an object, no casting.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @return value of the field
@@ -209,7 +206,7 @@ public class BSONDecorator {
   /**
    * Set field. Create the intermediate levels if necessary as
    * {@link BasicDBObject} fields.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field to be accessed
    * @param value
@@ -224,7 +221,7 @@ public class BSONDecorator {
 
   /**
    * Retrieve the parent of a field.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the field
    * @param createIfMissing
@@ -259,7 +256,7 @@ public class BSONDecorator {
 
   /**
    * Compute the name of the leaf field.
-   * 
+   *
    * @param fieldName
    *          fully qualified name of the target field
    * @return name of the field at the end of the tree (leaf)

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/utils/TestBSONDecorator.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/utils/TestBSONDecorator.java
@@ -92,4 +92,18 @@ public class TestBSONDecorator {
     assertArrayEquals("test2".getBytes(), dboc.getBytes("root3").array());
   }
 
+  @Test
+  public void testNullStringField() {
+    // Init the object used for testing
+    DBObject dbo1 = BasicDBObjectBuilder
+        .start()
+        .add("key1", null)
+        .get();
+    BSONDecorator dboc = new BSONDecorator(dbo1);
+
+    assertTrue(dboc.containsField("key1"));
+    assertNull(dboc.getUtf8String("key1"));
+
+    assertFalse(dboc.containsField("key2"));
+  }
 }


### PR DESCRIPTION
Gora currently returns new Utf8() on null field value in mongo mapping.
This patch fixes this.