### PR TITLE
GORA-424 Cache cursor size

### DIFF
--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/query/MongoDBResult.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/query/MongoDBResult.java
@@ -36,7 +36,7 @@ import com.mongodb.DBObject;
  * @author Damien Raude-Morvan <draudemorvan@dictanova.com>
  */
 public class MongoDBResult<K, T extends PersistentBase> extends
-    ResultBase<K, T> {
+        ResultBase<K, T> {
 
   /**
    * Reference to the cursor pointing to the results
@@ -55,7 +55,7 @@ public class MongoDBResult<K, T extends PersistentBase> extends
     } else if (size == 0) {
       return 1;
     } else {
-      return offset / size;
+      return offset / (float) size;
     }
   }
 
@@ -75,7 +75,7 @@ public class MongoDBResult<K, T extends PersistentBase> extends
     DBObject obj = cursor.next();
     key = (K) obj.get("_id");
     persistent = ((MongoStore<K, T>) getDataStore()).newInstance(obj,
-        getQuery().getFields());
+            getQuery().getFields());
     return persistent != null;
   }
 

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/query/MongoDBResult.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/query/MongoDBResult.java
@@ -31,7 +31,7 @@ import com.mongodb.DBObject;
 /**
  * MongoDB specific implementation of the {@link org.apache.gora.query.Result}
  * interface.
- * 
+ *
  * @author Fabien Poulard <fpoulard@dictanova.com>
  * @author Damien Raude-Morvan <draudemorvan@dictanova.com>
  */
@@ -42,6 +42,7 @@ public class MongoDBResult<K, T extends PersistentBase> extends
    * Reference to the cursor pointing to the results
    */
   private DBCursor cursor;
+  private int size;
 
   public MongoDBResult(DataStore<K, T> dataStore, Query<K, T> query) {
     super(dataStore, query);
@@ -49,12 +50,13 @@ public class MongoDBResult<K, T extends PersistentBase> extends
 
   @Override
   public float getProgress() throws IOException {
-    if (cursor == null)
+    if (cursor == null) {
       return 0;
-    else if (cursor.size() == 0)
+    } else if (size == 0) {
       return 1;
-    else
-      return offset / cursor.size();
+    } else {
+      return offset / size;
+    }
   }
 
   @Override
@@ -79,13 +81,13 @@ public class MongoDBResult<K, T extends PersistentBase> extends
 
   /**
    * Save the reference to the cursor that holds the actual results.
-   * 
+   *
    * @param cursor
    *          {@link DBCursor} obtained from a query execution and that holds
    *          the actual results
    */
   public void setCursor(DBCursor cursor) {
     this.cursor = cursor;
+    this.size = cursor.size();
   }
-
 }


### PR DESCRIPTION
MongoDBResult.getProgress calls cursor.size() which in turn issues count() request on underlying collection. This patch fixes this.