### PR TITLE
GORA-433 Non-Final Public Static Fields Should Be Final

### DIFF
--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
@@ -96,12 +96,12 @@ public class CassandraStore<K, T extends PersistentBase> extends DataStoreBase<K
    * Fixed string with value "UnionIndex" used to generate an extra column based on 
    * the original field's name
    */
-  public static String UNION_COL_SUFIX = "_UnionIndex";
+  public static final String UNION_COL_SUFIX = "_UnionIndex";
 
   /**
    * Default schema index with value "0" used when AVRO Union data types are stored
    */
-  public static int DEFAULT_UNION_SCHEMA = 0;
+  public static final int DEFAULT_UNION_SCHEMA = 0;
 
   /**
    * The values are Avro fields pending to be stored.

--- a/gora-compiler/src/main/java/org/apache/gora/compiler/GoraCompiler.java
+++ b/gora-compiler/src/main/java/org/apache/gora/compiler/GoraCompiler.java
@@ -36,7 +36,7 @@ import org.codehaus.jackson.node.JsonNodeFactory;
 
 public class GoraCompiler extends SpecificCompiler {
 
-  public static String DIRTY_BYTES_FIELD_NAME = "__g__dirty";
+  public static final String DIRTY_BYTES_FIELD_NAME = "__g__dirty";
   public static final int FIRST_UNMANAGED_FIELD_INDEX = 1;
 
   private static final Set<String> GORA_RESERVED_NAMES = new HashSet<String>();

--- a/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
+++ b/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
@@ -165,7 +165,7 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
    * Default schema index with value "0" used when AVRO Union data types are
    * stored
    */
-  public static int DEFAULT_UNION_SCHEMA = 0;
+  public static final int DEFAULT_UNION_SCHEMA = 0;
 
   /*
    * Create a threadlocal map for the datum readers and writers, because they


### PR DESCRIPTION
Non-final public static fields can be changed by external classes (by a malicious code or accidentally).