### PR TITLE
GORA-434 Documents are Not Committed Into Solr Store

### DIFF
--- a/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
+++ b/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
@@ -783,9 +783,7 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
 
   @Override
   public void close() {
-    // In testing, the index gets closed before the commit in flush() can happen
-    // so an exception gets thrown
-    // flush();
+    flush();
   }
 
   private void add(ArrayList<SolrInputDocument> batch, int commitWithin)


### PR DESCRIPTION
Fix for uncommitted documents which are at last buffer when buffer is not equal to default commit size.