### PR TITLE
GORA-438 Erroneous Exception Message at IOUtils.java

### DIFF
--- a/gora-core/src/main/java/org/apache/gora/util/IOUtils.java
+++ b/gora-core/src/main/java/org/apache/gora/util/IOUtils.java
@@ -79,7 +79,7 @@ public class IOUtils {
         return obj;
       }
     }
-    throw new IOException("cannot write to DataOutput of instance:"
+    throw new IOException("cannot read from DataInput of instance:"
         + in.getClass());
   }
 


### PR DESCRIPTION
Erroneous exception message: "cannot write to DataOutput of instance:" at readObject method of IOUtils.java is fixed.