### PR TITLE
GORA-448 Upgrade MongoDB Java Driver Version

### DIFF
--- a/gora-mongodb/pom.xml
+++ b/gora-mongodb/pom.xml
@@ -52,8 +52,8 @@
   <properties>
     <osgi.import>*</osgi.import>
     <osgi.export>org.apache.gora.mongodb*;version="${project.version}";-noimport:=true</osgi.export>
-    <mongo.driver.version>2.13.1</mongo.driver.version>
-    <mongo.embed.version>1.47.3</mongo.embed.version>
+    <mongo.driver.version>3.1.0</mongo.driver.version>
+    <mongo.embed.version>1.50.0</mongo.embed.version>
   </properties>
 
   <build>

--- a/gora-mongodb/pom.xml
+++ b/gora-mongodb/pom.xml
@@ -52,8 +52,8 @@
   <properties>
     <osgi.import>*</osgi.import>
     <osgi.export>org.apache.gora.mongodb*;version="${project.version}";-noimport:=true</osgi.export>
-    <mongo.driver.version>3.1.0</mongo.driver.version>
-    <mongo.embed.version>1.50.0</mongo.embed.version>
+    <mongo.driver.version>3.2.0</mongo.driver.version>
+    <mongo.embed.version>1.50.2</mongo.embed.version>
   </properties>
 
   <build>

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
@@ -231,7 +231,7 @@ public class MongoStore<K, T extends PersistentBase> extends
     // otherwise creation is deferred
     mongoClientColl.setDBEncoderFactory(GoraDBEncoder.FACTORY);
 
-    LOG.info("Collection {} has been created for Mongo instance {}.",
+    LOG.debug("Collection {} has been created for Mongo instance {}.",
         new Object[] { mapping.getCollectionName(), mongoClientDB.getMongo() });
   }
 
@@ -246,7 +246,7 @@ public class MongoStore<K, T extends PersistentBase> extends
     // If initialized, simply drop the collection
     mongoClientColl.drop();
 
-    LOG.info(
+    LOG.debug(
         "Collection {} has been dropped for Mongo instance {}.",
         new Object[] { mongoClientColl.getFullName(), mongoClientDB.getMongo() });
   }
@@ -266,7 +266,7 @@ public class MongoStore<K, T extends PersistentBase> extends
   public void flush() {
     for (MongoClient client : mapsOfClients.values()) {
       client.fsync(false);
-      LOG.info("Forced synced of database for Mongo instance {}.",
+      LOG.debug("Forced synced of database for Mongo instance {}.",
           new Object[] { client });
     }
   }

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
@@ -638,8 +638,12 @@ public class MongoStore<K, T extends PersistentBase> extends
       // Try auto-conversion of BSON data to ObjectId
       // It will work if data is stored as String or as ObjectId
       Object bin = easybson.get(docf);
-      ObjectId id = ObjectId.massageToObjectId(bin);
-      result = new Utf8(id.toString());
+      if (bin instanceof String) {
+        ObjectId id = new ObjectId((String) bin);
+        result = new Utf8(id.toString());
+      } else {
+        result = new Utf8(bin.toString());
+      }
     } else if (storeType == DocumentFieldType.DATE) {
       Object bin = easybson.get(docf);
       if (bin instanceof Date) {

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
@@ -154,9 +154,8 @@ public class MongoStore<K, T extends PersistentBase> extends
       optBuilder.writeConcern(WriteConcern.valueOf(params.getWriteConcern()));
     }
     // If configuration contains a login + secret, try to authenticated with DB
-    List<MongoCredential> credentials = null;
+    List<MongoCredential> credentials = new ArrayList<>();
     if (params.getLogin() != null && params.getSecret() != null) {
-      credentials = new ArrayList<>();
       credentials.add(MongoCredential.createCredential(params.getLogin(), params.getDbname(), params.getSecret().toCharArray()));
     }
     // Build server address

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
@@ -276,11 +276,6 @@ public class MongoStore<K, T extends PersistentBase> extends
    */
   @Override
   public void close() {
-    mongoClientDB.cleanCursors(true);
-    // mongoClient.close();
-    // LOG.info("Closed database and connection for Mongo instance {}.",
-    // new Object[]{mongoClient});
-    LOG.debug("Not closed!!!");
   }
 
   /**

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/utils/BSONDecorator.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/utils/BSONDecorator.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,15 +17,14 @@
  */
 package org.apache.gora.mongodb.utils;
 
-import java.nio.ByteBuffer;
-import java.util.Date;
-
-import org.apache.avro.util.Utf8;
-import org.bson.BSONObject;
-
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+import org.apache.avro.util.Utf8;
+import org.bson.BSONObject;
+
+import java.nio.ByteBuffer;
+import java.util.Date;
 
 /**
  * Utility class to build {@link DBObject} used by MongoDB in an easy way by
@@ -55,10 +54,9 @@ public class BSONDecorator {
    * as a fully qualified name that is the path to the field from the root of
    * the document (for example: "field1" or "parent.child.field2").
    *
-   * @param fieldName
-   *          fully qualified name of the field
+   * @param fieldName fully qualified name of the field
    * @return true if the field and all its parents exists in the decorated
-   *         {@link DBObject}, false otherwise
+   * {@link DBObject}, false otherwise
    */
   public boolean containsField(String fieldName) {
     // Prepare for in depth setting
@@ -81,20 +79,18 @@ public class BSONDecorator {
   /**
    * Access field as a {@link BasicDBObject}.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a {@link BasicDBObject}
    */
   public BasicDBObject getDBObject(String fieldName) {
     return (BasicDBObject) getFieldParent(fieldName)
-        .get(getLeafName(fieldName));
+            .get(getLeafName(fieldName));
   }
 
   /**
    * Access field as a {@link BasicDBList}.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a {@link BasicDBList}
    */
   public BasicDBList getDBList(String fieldName) {
@@ -104,68 +100,67 @@ public class BSONDecorator {
   /**
    * Access field as a boolean.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a boolean
    */
   public Boolean getBoolean(String fieldName) {
     BasicDBObject parent = getFieldParent(fieldName);
-    return parent.getBoolean(getLeafName(fieldName));
+    String lf = getLeafName(fieldName);
+    return parent.containsField(lf) ? parent.getBoolean(lf) : null;
   }
 
   /**
    * Access field as a double.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a double
    */
   public Double getDouble(String fieldName) {
     BasicDBObject parent = getFieldParent(fieldName);
-    return parent.getDouble(getLeafName(fieldName));
+    String lf = getLeafName(fieldName);
+    return parent.containsField(lf) ? parent.getDouble(lf) : null;
   }
 
   /**
    * Access field as a int.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a double
    */
   public Integer getInt(String fieldName) {
     BasicDBObject parent = getFieldParent(fieldName);
-    return parent.getInt(getLeafName(fieldName));
+    String lf = getLeafName(fieldName);
+    return parent.containsField(lf) && parent.get(lf) != null ? parent.getInt(lf) : null;
   }
 
   /**
    * Access field as a long.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a double
    */
   public Long getLong(String fieldName) {
     BasicDBObject parent = getFieldParent(fieldName);
-    return parent.getLong(getLeafName(fieldName));
+    String lf = getLeafName(fieldName);
+    return parent.containsField(lf) ? parent.getLong(lf) : null;
   }
 
   /**
    * Access field as a date.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a date
    */
   public Date getDate(String fieldName) {
     BasicDBObject parent = getFieldParent(fieldName);
-    return parent.getDate(getLeafName(fieldName));
+    String lf = getLeafName(fieldName);
+    return parent.getDate(lf);
   }
 
   /**
    * Access field as a Utf8 string.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field as a {@link Utf8} string
    */
   public Utf8 getUtf8String(String fieldName) {
@@ -177,8 +172,7 @@ public class BSONDecorator {
   /**
    * Access field as bytes.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field
    */
   public ByteBuffer getBytes(String fieldName) {
@@ -194,8 +188,7 @@ public class BSONDecorator {
   /**
    * Access field as an object, no casting.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
+   * @param fieldName fully qualified name of the field to be accessed
    * @return value of the field
    */
   public Object get(String fieldName) {
@@ -207,10 +200,8 @@ public class BSONDecorator {
    * Set field. Create the intermediate levels if necessary as
    * {@link BasicDBObject} fields.
    *
-   * @param fieldName
-   *          fully qualified name of the field to be accessed
-   * @param value
-   *          value of the field
+   * @param fieldName fully qualified name of the field to be accessed
+   * @param value     value of the field
    */
   public void put(String fieldName, Object value) {
     BasicDBObject parent = getFieldParent(fieldName, true);
@@ -222,13 +213,10 @@ public class BSONDecorator {
   /**
    * Retrieve the parent of a field.
    *
-   * @param fieldName
-   *          fully qualified name of the field
-   * @param createIfMissing
-   *          create the intermediate fields if necessary
+   * @param fieldName       fully qualified name of the field
+   * @param createIfMissing create the intermediate fields if necessary
    * @return the parent of the field
-   * @throws IllegalAccessError
-   *           if the field does not exist
+   * @throws IllegalAccessError if the field does not exist
    */
   private BasicDBObject getFieldParent(String fieldName, boolean createIfMissing) {
     String[] fields = fieldName.split("\\.");
@@ -242,7 +230,7 @@ public class BSONDecorator {
           intermediate.put(fields[i], new BasicDBObject());
         else
           throw new IllegalAccessError("The field '" + fieldName
-              + "' does not exist: '" + fields[i] + "' is missing.");
+                  + "' does not exist: '" + fields[i] + "' is missing.");
       intermediate = (BasicDBObject) intermediate.get(fields[i]);
       i++;
     }
@@ -257,8 +245,7 @@ public class BSONDecorator {
   /**
    * Compute the name of the leaf field.
    *
-   * @param fieldName
-   *          fully qualified name of the target field
+   * @param fieldName fully qualified name of the target field
    * @return name of the field at the end of the tree (leaf)
    */
   private String getLeafName(String fieldName) {

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/GoraMongodbTestDriver.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/GoraMongodbTestDriver.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,23 +17,25 @@
  */
 package org.apache.gora.mongodb;
 
-import org.apache.gora.GoraTestDriver;
-import org.apache.gora.mongodb.store.MongoStore;
-import org.apache.gora.mongodb.store.MongoStoreParameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
-
+import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.IMongodConfig;
 import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.runtime.Network;
+import org.apache.gora.GoraTestDriver;
+import org.apache.gora.mongodb.store.MongoStore;
+import org.apache.gora.mongodb.store.MongoStoreParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Driver to set up an embedded MongoDB database instance for use in our
@@ -43,7 +45,7 @@ import de.flapdoodle.embed.process.runtime.Network;
 public class GoraMongodbTestDriver extends GoraTestDriver {
 
   private static Logger log = LoggerFactory
-      .getLogger(GoraMongodbTestDriver.class);
+          .getLogger(GoraMongodbTestDriver.class);
 
   private MongodExecutable _mongodExe;
   private MongodProcess _mongod;
@@ -68,7 +70,13 @@ public class GoraMongodbTestDriver extends GoraTestDriver {
   @Override
   public void setUpClass() throws Exception {
     super.setUpClass();
-    MongodStarter runtime = MongodStarter.getDefaultInstance();
+
+    IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder()
+            .defaultsWithLogger(Command.MongoD, log)
+            .processOutput(ProcessOutput.getDefaultInstanceSilent())
+            .build();
+
+    MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
 
     int port = Network.getFreeServerPort();
     IMongodConfig mongodConfig = new MongodConfigBuilder()

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,27 +17,26 @@
  */
 package org.apache.gora.mongodb.store;
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import org.apache.avro.util.Utf8;
 import org.apache.gora.examples.generated.Employee;
 import org.apache.gora.examples.generated.WebPage;
 import org.apache.gora.mongodb.GoraMongodbTestDriver;
 import org.apache.gora.mongodb.utils.BSONDecorator;
+import org.apache.gora.query.Query;
+import org.apache.gora.query.Result;
 import org.apache.gora.store.DataStore;
 import org.apache.gora.store.DataStoreTestBase;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
+import java.io.IOException;
 import java.util.Collections;
 
-import org.apache.avro.util.Utf8;
-import org.apache.gora.query.Query;
-import org.apache.gora.query.Result;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public abstract class TestMongoStore extends DataStoreTestBase {
 

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore30.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore30.java
@@ -21,7 +21,7 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import org.apache.gora.mongodb.GoraMongodbTestDriver;
 
 /**
- * Perform {@link TestMongoStore} tests on MongoDB 3.0.x branch.
+ * Perform {@link TestMongoStore} tests on MongoDB 3.0.x server.
  */
 public class TestMongoStore30 extends TestMongoStore {
 

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore32.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore32.java
@@ -21,11 +21,11 @@ import de.flapdoodle.embed.mongo.distribution.Version;
 import org.apache.gora.mongodb.GoraMongodbTestDriver;
 
 /**
- * Perform {@link TestMongoStore} tests on MongoDB 2.6.x server.
+ * Perform {@link TestMongoStore} tests on MongoDB 3.2.x server.
  */
-public class TestMongoStore26 extends TestMongoStore {
+public class TestMongoStore32 extends TestMongoStore {
 
   static {
-    setTestDriver(new GoraMongodbTestDriver(Version.Main.V2_6));
+    setTestDriver(new GoraMongodbTestDriver(Version.Main.V3_2));
   }
 }

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/utils/TestBSONDecorator.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/utils/TestBSONDecorator.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,16 +17,15 @@
  */
 package org.apache.gora.mongodb.utils;
 
-import static org.junit.Assert.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
-import org.junit.Test;
-
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBObject;
+import static org.junit.Assert.*;
 
 public class TestBSONDecorator {
 
@@ -34,12 +33,12 @@ public class TestBSONDecorator {
   public void testContainsField() {
     // Init the object used for testing
     DBObject dbo1 = BasicDBObjectBuilder
-        .start()
-        .add("root0", "value")
-        .add("root1", new BasicDBObject("leaf1", 1))
-        .add("root2",
-            new BasicDBObject("parent1", new BasicDBObject("leaf2", "test")))
-        .get();
+            .start()
+            .add("root0", "value")
+            .add("root1", new BasicDBObject("leaf1", 1))
+            .add("root2",
+                    new BasicDBObject("parent1", new BasicDBObject("leaf2", "test")))
+            .get();
     BSONDecorator dboc = new BSONDecorator(dbo1);
 
     // Root level field, does exist
@@ -68,25 +67,25 @@ public class TestBSONDecorator {
   public void testBinaryField() {
     // Init the object used for testing
     DBObject dbo1 = BasicDBObjectBuilder
-        .start()
-        .add("root0", "value")
-        .add("root1", new BasicDBObject("leaf1", "abcdefgh".getBytes(Charset.defaultCharset())))
-        .add(
-            "root2",
-            new BasicDBObject("parent1", new BasicDBObject("leaf2", "test"
-                .getBytes(Charset.defaultCharset()))))
-        .add("root3", ByteBuffer.wrap("test2".getBytes(Charset.defaultCharset()))).get();
+            .start()
+            .add("root0", "value")
+            .add("root1", new BasicDBObject("leaf1", "abcdefgh".getBytes(Charset.defaultCharset())))
+            .add(
+                    "root2",
+                    new BasicDBObject("parent1", new BasicDBObject("leaf2", "test"
+                            .getBytes(Charset.defaultCharset()))))
+            .add("root3", ByteBuffer.wrap("test2".getBytes(Charset.defaultCharset()))).get();
     BSONDecorator dboc = new BSONDecorator(dbo1);
 
     // Access first bytes field
     assertTrue(dboc.containsField("root1.leaf1"));
     assertArrayEquals("abcdefgh".getBytes(Charset.defaultCharset()), dboc.getBytes("root1.leaf1")
-        .array());
+            .array());
 
     // Access second bytes field
     assertTrue(dboc.containsField("root2.parent1.leaf2"));
     assertArrayEquals("test".getBytes(Charset.defaultCharset()), dboc.getBytes("root2.parent1.leaf2")
-        .array());
+            .array());
 
     // Access third bytes field
     assertTrue(dboc.containsField("root3"));
@@ -97,14 +96,30 @@ public class TestBSONDecorator {
   public void testNullStringField() {
     // Init the object used for testing
     DBObject dbo1 = BasicDBObjectBuilder
-        .start()
-        .add("key1", null)
-        .get();
+            .start()
+            .add("key1", null)
+            .get();
     BSONDecorator dboc = new BSONDecorator(dbo1);
 
     assertTrue(dboc.containsField("key1"));
     assertNull(dboc.getUtf8String("key1"));
 
     assertFalse(dboc.containsField("key2"));
+  }
+
+  @Test
+  public void testNullFields() {
+    BSONDecorator dboc = new BSONDecorator(new BasicDBObject());
+
+    assertNull(dboc.getInt("key1"));
+    assertNull(dboc.getLong("key1"));
+    assertNull(dboc.getDouble("key1"));
+    assertNull(dboc.getUtf8String("key1"));
+    assertNull(dboc.getBoolean("key1"));
+    assertNull(dboc.getBytes("key1"));
+    assertNull(dboc.getDate("key1"));
+
+    assertNull(dboc.getDBObject("key1"));
+    assertNull(dboc.getDBList("key1"));
   }
 }


### PR DESCRIPTION
PR for GORA-448

* Upgrade to mongo-java-driver 3.2.0
* Upgrade to de.flapdoodle.embed.mongo 1.50.2
* Enable integration tests over Mongo 3.2 server
* Improve handling of null fields in BSONDecorator