### PR TITLE
GORA-277 Create gora-maven-plugin

### DIFF
--- a/gora-maven-plugin/.gitignore
+++ b/gora-maven-plugin/.gitignore
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.idea/
+target/
+*.iml

--- a/gora-maven-plugin/README.md
+++ b/gora-maven-plugin/README.md
@@ -1,0 +1,48 @@
+#Apache Gora Maven Plugin
+
+The Gora Maven Plugin is used to generate Java sources from Apache Avro *.json schema descriptors.
+The plugin code was originally written by Gerhard Gossen and laterly by Viacheslav Dobromyslov.
+
+##Goals Overview
+
+The Gora Maven Plugin has two goals:
+
+* gora:generate generates Java sources from Apache Avro schema descriptors,
+* gora:help shows usage help.
+
+##Build plugin
+
+To build and install plugin on the local machine just run:
+    
+    mvn clean install
+    
+##Usage
+
+Add to your `pom.xml` the following plugin:
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.gora.maven.plugin</groupId>
+                <artifactId>gora-maven-plugin</artifactId>
+                <version>${gora.version}</version>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/avro</sourceDirectory>
+                    <outputDirectory>${basedir}/src/main/java</outputDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
+And then run:
+
+    mvn gora:generate
+
+##Related links
+
+* http://gora.apache.org/current/tutorial.html
+* https://issues.apache.org/jira/browse/GORA-277
+
+###License
+
+This work is provided under Apache License version 2.0. See LICENSE for more details.

--- a/gora-maven-plugin/pom.xml
+++ b/gora-maven-plugin/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.gora</groupId>
+    <artifactId>gora</artifactId>
+    <version>0.7-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <artifactId>gora-maven-plugin</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>Apache Gora :: Maven Plugin</name>
+  <url>http://gora.apache.org</url>
+  <description>
+    This Maven plugin helps to generate Java code from Apache 
+    Avro *.json files using Apache Gora compiler. This plugin was originally
+    written and contributed by dobromyslov
+  </description>
+
+  <inceptionYear>2010</inceptionYear>
+  <organization>
+    <name>The Apache Software Foundation</name>
+    <url>http://www.apache.org/</url>
+  </organization>
+  <issueManagement>
+    <system>JIRA</system>
+    <url>https://issues.apache.org/jira/browse/GORA</url>
+  </issueManagement>
+  <ciManagement>
+    <system>Jenkins</system>
+    <url>https://builds.apache.org/job/Gora-trunk/</url>
+  </ciManagement>
+
+  <properties>
+    <osgi.import>*</osgi.import>
+    <osgi.export>org.apache.gora.maven*;version="${project.version}";-noimport:=true</osgi.export>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>3.3.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.22</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.gora</groupId>
+      <artifactId>gora-compiler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.3</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.plexus</groupId>
+      <artifactId>plexus-build-api</artifactId>
+      <version>0.0.7</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          <goalPrefix>gora</goalPrefix>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/gora-maven-plugin/src/main/java/org/apache/gora/maven/plugin/AbstractGoraMojo.java
+++ b/gora-maven-plugin/src/main/java/org/apache/gora/maven/plugin/AbstractGoraMojo.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.avro.SchemaParseException;
+import org.apache.gora.compiler.GoraCompiler;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.jackson.JsonLocation;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.plexus.util.Scanner;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+public abstract class AbstractGoraMojo extends AbstractMojo {
+
+  /**
+   * License to chose for created files.
+   *
+   * Currently ignored, as schema compiler does not support this parameter
+   * yet.
+   */
+  @Parameter(defaultValue = "ASLv2")
+  protected String license;
+
+  /**
+   * Patterns for file inclusion
+   */
+  @Parameter(defaultValue = "*.json")
+  protected String[] includes;
+
+  /**
+   * Patterns for file exclusion
+   */
+  @Parameter(defaultValue = ".*")
+  protected String[] excludes;
+
+  @Component
+  protected MavenProject project;
+
+  @Component
+  protected BuildContext context;
+
+  public AbstractGoraMojo() {
+    super();
+  }
+
+  protected void compile() throws IOException {
+    File sourceDirectory = getSourcesDirectory();
+    File outputDirectory = getOutputDirectory();
+
+    if (!outputDirectory.exists()) {
+      outputDirectory.mkdirs();
+    }
+
+    Scanner fileScanner = context.newScanner(sourceDirectory, true);
+    fileScanner.setIncludes(includes);
+    fileScanner.setExcludes(excludes);
+    fileScanner.scan();
+    File basedir = fileScanner.getBasedir();
+
+    List<File> changedFiles = new ArrayList<File>();
+    for (String fileName : fileScanner.getIncludedFiles()) {
+      File file = new File(basedir, fileName);
+      changedFiles.add(file);
+      context.removeMessages(file);
+    }
+    if (!changedFiles.isEmpty()) {
+      try {
+        File[] schemaFile = changedFiles.toArray(new File[changedFiles.size()]);
+        GoraCompiler.compileSchema(schemaFile, outputDirectory);
+      } catch (SchemaParseException e) {
+        if (e.getCause() != null && e.getCause() instanceof JsonParseException) {
+          attachErrorMessage((JsonParseException) e.getCause());
+        } else {
+          throw e;
+        }
+      }
+    }
+    context.refresh(outputDirectory);
+  }
+
+  private void attachErrorMessage(JsonParseException e) {
+    JsonLocation location = e.getLocation();
+    File file;
+    if (location.getSourceRef() instanceof File) {
+      file = (File) location.getSourceRef();
+    } else {
+      file = null;
+    }
+    context.addMessage(file, location.getLineNr(), location.getColumnNr(), e.getLocalizedMessage(), BuildContext.SEVERITY_ERROR, e);
+  }
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    try {
+      compile();
+      registerSourceDirectory(project, getSourcesDirectory().getPath());
+      registerSourceDirectory(project, getOutputDirectory().getPath());
+    } catch (IOException e) {
+      throw new MojoExecutionException(
+          "Could not compile schema in " + getSourcesDirectory(), e);
+    }
+  }
+
+  protected abstract File getSourcesDirectory();
+
+  protected abstract File getOutputDirectory();
+
+  /**
+   * Register the given path as a source directory.
+   *
+   * The directory will be used as input for the compilation step, as well as
+   * shown as a source folder in IDEs.
+   *
+   * @param project
+   *            project descriptor
+   * @param path
+   *            relative path to a source directory
+   */
+  protected abstract void registerSourceDirectory(MavenProject project, String path);
+}

--- a/gora-maven-plugin/src/main/java/org/apache/gora/maven/plugin/GenerateMojo.java
+++ b/gora-maven-plugin/src/main/java/org/apache/gora/maven/plugin/GenerateMojo.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.maven.plugin;
+
+import java.io.File;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Goal which compiles Gora schemas.
+ *
+ */
+@Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+public class GenerateMojo extends AbstractGoraMojo {
+  /**
+   * The source directory of Apache Avro files. This directory is added to the
+   * classpath at schema compiling time. All files can therefore be referenced
+   * as classpath resources following the directory structure under the source
+   * directory.
+   *
+   */
+  @Parameter(defaultValue = "${basedir}/src/main/avro")
+  private File sourceDirectory;
+
+  @Parameter(defaultValue = "${basedir}/src/main/java")
+  private File outputDirectory;
+
+  @Override
+  protected File getSourcesDirectory() {
+    return sourceDirectory;
+  }
+
+  @Override
+  protected File getOutputDirectory() {
+    return outputDirectory;
+  }
+
+  @Override
+  protected void registerSourceDirectory(MavenProject project, String path) {
+    project.addCompileSourceRoot(path);
+  }
+}

--- a/gora-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/gora-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>generate</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <runOnIncremental>true</runOnIncremental>
+                    <runOnConfiguration>true</runOnConfiguration>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,19 @@
                     <ignore />
                   </action>
                 </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>de.thetaphi</groupId>
+                    <artifactId>forbiddenapis</artifactId>
+                    <versionRange>2.0</versionRange>
+                    <goals>
+                      <goal>testCheck</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
@@ -446,7 +459,7 @@
       <plugin>
         <groupId>de.thetaphi</groupId>
         <artifactId>forbiddenapis</artifactId>
-        <version>1.8</version>
+        <version>2.0</version>
         <configuration>
           <!-- disallow undocumented classes like sun.misc.Unsafe: -->
           <internalRuntimeForbidden>true</internalRuntimeForbidden>
@@ -691,6 +704,7 @@
     <!-- module>gora-lucene</module -->
     <!--module>gora-dynamodb</module -->
     <!--module>gora-sql</module -->
+    <module>gora-maven-plugin</module>
     <module>gora-mongodb</module>
     <module>gora-shims-hadoop</module>
     <module>gora-shims-hadoop1</module>


### PR DESCRIPTION
This issue addresses [GORA-277](https://issues.apache.org/jira/browse/GORA-277) by combining work by both Gerhard Gossen and Viacheslav Dobromyslov in order to produce the very useful gora-maven-plugin module for us to publish and use for easily generating Gora Java beans. 
I've [reached out](https://github.com/dobromyslov/gora-maven-plugin/issues/1) to @dobromyslov, hopefully the move to merge this code into Gora master will be welcomed. 