### PR TITLE
GORA-467 Flushing DataOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/gora-accumulo/src/test/java/org/apache/gora/accumulo/store/PartitionTest.java
+++ b/gora-accumulo/src/test/java/org/apache/gora/accumulo/store/PartitionTest.java
@@ -39,6 +39,7 @@ public class PartitionTest {
     DataOutputStream dos = new DataOutputStream(baos);
     try {
       dos.writeLong(l);
+      dos.flush();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/gora-core/src/test/java/org/apache/gora/util/TestWritableUtils.java
+++ b/gora-core/src/test/java/org/apache/gora/util/TestWritableUtils.java
@@ -44,6 +44,7 @@ public class TestWritableUtils {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     DataOutput out = new DataOutputStream(bos);
     WritableUtils.writeProperties(out, props);
+    ((DataOutputStream)out).flush();
     
     DataInput in = new DataInputStream(new ByteArrayInputStream(bos.toByteArray()));
     


### PR DESCRIPTION
When a DataOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the DataOutputStream before invoking the underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request add a flush method before toByteArray. I have also added a [Jira Issue](https://issues.apache.org/jira/browse/GORA-467).