### PR TITLE
GORA-443 Upgrade HBase to 1.2.0

### DIFF
--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -59,11 +59,14 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.jdom.Document;
@@ -90,7 +93,7 @@ implements Configurable {
   private static final String SCANNER_CACHING_PROPERTIES_KEY = "scanner.caching" ;
   private static final int SCANNER_CACHING_PROPERTIES_DEFAULT = 0 ;
   
-  private volatile HBaseAdmin admin;
+  private volatile Admin admin;
 
   private volatile HBaseTableConnection table;
 
@@ -112,7 +115,8 @@ implements Configurable {
       
       super.initialize(keyClass, persistentClass, properties);
       this.conf = HBaseConfiguration.create(getConf());
-      admin = new HBaseAdmin(this.conf);
+      Connection connection = ConnectionFactory.createConnection(getConf());
+      admin = connection.getAdmin();//new HBaseAdmin(this.conf);
       mapping = readMapping(getConf().get(PARSE_MAPPING_FILE_KEY, DEFAULT_MAPPING_FILE));
       filterUtil = new HBaseFilterUtil<>(this.conf);
     } catch (FileNotFoundException ex) {
@@ -184,8 +188,8 @@ implements Configurable {
       if(!schemaExists()) {
         return;
       }
-      admin.disableTable(getSchemaName());
-      admin.deleteTable(getSchemaName());
+      admin.disableTable(TableName.valueOf(getSchemaName()));
+      admin.deleteTable(TableName.valueOf(getSchemaName()));
     } catch(IOException ex2){
       LOG.error(ex2.getMessage(), ex2);
     }
@@ -194,7 +198,7 @@ implements Configurable {
   @Override
   public boolean schemaExists() {
     try{
-      return admin.tableExists(mapping.getTableName());
+      return admin.tableExists(TableName.valueOf(mapping.getTableName()));
     } catch(IOException ex2){
       LOG.error(ex2.getMessage(), ex2);
       return false;
@@ -269,16 +273,16 @@ implements Configurable {
     case UNION:
       if (isNullable(schema) && o == null) {
         if (qualifier == null) {
-          delete.deleteFamily(hcol.getFamily());
+          delete.addFamily(hcol.getFamily());
         } else {
-          delete.deleteColumn(hcol.getFamily(), qualifier);
+          delete.addColumns(hcol.getFamily(), qualifier);
         }
       } else {
 //        int index = GenericData.get().resolveUnion(schema, o);
         int index = getResolvedUnionIndex(schema);
         if (index > 1) {  //if more than 2 type in union, serialize directly for now
           byte[] serializedBytes = toBytes(o, schema);
-          put.add(hcol.getFamily(), qualifier, serializedBytes);
+          put.addColumn(hcol.getFamily(), qualifier, serializedBytes);
         } else {
           Schema resolvedSchema = schema.getTypes().get(index);
           addPutsAndDeletes(put, delete, o, resolvedSchema.getType(),
@@ -290,9 +294,9 @@ implements Configurable {
       // if it's a map that has been modified, then the content should be replaced by the new one
       // This is because we don't know if the content has changed or not.
       if (qualifier == null) {
-        delete.deleteFamily(hcol.getFamily());
+        delete.addFamily(hcol.getFamily());
       } else {
-        delete.deleteColumn(hcol.getFamily(), qualifier);
+        delete.addColumns(hcol.getFamily(), qualifier);
       }
       @SuppressWarnings({ "rawtypes", "unchecked" })
       Set<Entry> set = ((Map) o).entrySet();
@@ -312,7 +316,7 @@ implements Configurable {
       break;
     default:
       byte[] serializedBytes = toBytes(o, schema);
-      put.add(hcol.getFamily(), qualifier, serializedBytes);
+      put.addColumn(hcol.getFamily(), qualifier, serializedBytes);
       break;
     }
   }
@@ -573,10 +577,10 @@ implements Configurable {
       break;
     case MAP:
     case ARRAY:
-      delete.deleteFamily(col.family);
+      delete.addFamily(col.family);
       break;
     default:
-      delete.deleteColumn(col.family, col.qualifier);
+      delete.addColumns(col.family, col.qualifier);
       break;
     }
   }

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/util/HBaseClusterSingleton.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/util/HBaseClusterSingleton.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -89,7 +90,7 @@ public final class HBaseClusterSingleton {
     htu.getConfiguration().setInt("zookeeper.session.timeout", 20000);
     //htu.getConfiguration().set("hbase.zookeeper.quorum", "localhost");
     //htu.getConfiguration().setInt("hbase.zookeeper.property.clientPort", 2181);
-    
+
     try {
       LOG.info("Start HBase mini cluster.");
       hbaseCluster = htu.startMiniCluster(numServers);
@@ -101,7 +102,7 @@ public final class HBaseClusterSingleton {
       LOG.info("Start mini mapreduce cluster.");
       htu.startMiniMapReduceCluster(numServers);
       LOG.info("After mini mapreduce cluster start-up.");
-      */
+       */
     } catch (Exception ex) {
       throw new RuntimeException("Minicluster not starting.");
     } finally {
@@ -152,8 +153,8 @@ public final class HBaseClusterSingleton {
    */
   public void ensureTable(byte[] tableName, byte[][] cfs) throws IOException {
     HBaseAdmin admin = htu.getHBaseAdmin();
-    if (!admin.tableExists(tableName)) {
-      HTable hTable = htu.createTable(tableName, cfs);
+    if (!admin.tableExists(TableName.valueOf(tableName))) {
+      HTable hTable = htu.createTable(TableName.valueOf(tableName), cfs);
       hTable.close();
     }
   }
@@ -165,12 +166,12 @@ public final class HBaseClusterSingleton {
   public void truncateAllTables() throws Exception {
     HBaseAdmin admin = htu.getHBaseAdmin();
     for(HTableDescriptor table:admin.listTables()) {
-      HTable hTable = htu.truncateTable(table.getName());
+      HTable hTable = htu.truncateTable(TableName.valueOf(table.getTableName().getName()));
       hTable.close();
     }
   }
-  
-  
+
+
   /**
    * Delete all tables
    * @throws Exception
@@ -178,8 +179,9 @@ public final class HBaseClusterSingleton {
   public void deleteAllTables() throws Exception {
     HBaseAdmin admin = htu.getHBaseAdmin();
     for(HTableDescriptor table:admin.listTables()) {
-      admin.disableTable(table.getName());
-      admin.deleteTable(table.getName());
+      admin.disableTable(table.getTableName().getName());
+      admin.disableTable(TableName.valueOf(table.getTableName().getName()));
+      admin.deleteTable(TableName.valueOf(table.getTableName().getName()));
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -726,8 +726,8 @@
     <hadoop-2.version>2.5.2</hadoop-2.version>
     <hadoop-1.test.version>1.2.1</hadoop-1.test.version>
     <hadoop-2.test.version>2.5.2</hadoop-2.test.version>
-    <hbase.version>0.98.8-hadoop2</hbase.version>
-    <hbase.test.version>0.98.8-hadoop2</hbase.test.version>
+    <hbase.version>1.2.0</hbase.version>
+    <hbase.test.version>1.2.0</hbase.test.version>
     <cxf-rt-frontend-jaxrs.version>2.5.2</cxf-rt-frontend-jaxrs.version>
     <!-- Amazon Dependencies -->
     <amazon.version>1.10.55</amazon.version>


### PR DESCRIPTION
This is a (currently failing) attempt to upgrade gora-hbase to HBase 1.2.0
Failing tests are as numerous... however with a bit more sleep I am sure I/we can figure it out. 
This is a good start for now, most of the APi upgrades have been undertaken however within the Maven compile output log you will see deprecation on some methods... we will wish to fix this at some stage I would imagine.