### PR TITLE
Fixed issue GORA-503

### DIFF
--- a/gora-core/src/main/java/org/apache/gora/persistency/impl/PersistentBase.java
+++ b/gora-core/src/main/java/org/apache/gora/persistency/impl/PersistentBase.java
@@ -77,8 +77,6 @@ public abstract class PersistentBase extends SpecificRecordBase implements
   }
 
   private void clearDirynessIfFieldIsDirtyable(int fieldIndex) {
-    if (fieldIndex == 0)
-      return;
     Object value = get(fieldIndex);
     if (value instanceof Dirtyable) {
       ((Dirtyable) value).clearDirty();
@@ -119,8 +117,6 @@ public abstract class PersistentBase extends SpecificRecordBase implements
   }
 
   private boolean checkIfMutableFieldAndDirty(Field field) {
-    if (field.pos() == 0)
-      return false;
     switch (field.schema().getType()) {
     case RECORD:
     case MAP:


### PR DESCRIPTION
Field index 0 is always considered as clean even if it is dirty.