### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Apache Gora Project
+# Apache Gora Project
 
 <img src="http://gora.apache.org/resources/img/powered-by-gora.png" align="right" width="300" />
 
@@ -14,7 +14,7 @@ and persistence for big data. Gora supports persisting to column stores,
 key value stores, document stores and RDBMSs, and analyzing the data 
 with extensive Apache Hadoop MapReduce support. 
 
-##Why Gora?
+## Why Gora?
 
 Although there are various excellent ORM frameworks for relational
 databases, data modeling in NoSQL data stores differ profoundly
@@ -45,7 +45,7 @@ grouped as follows.
 * MapReduce support : Out-of-the-box and extensive MapReduce (Apache
   Hadoop) support for data in the data store.
 
-#Background
+# Background
 
 ORM stands for Object Relation Mapping. It is a technology which
 abstacts the persistency layer (mostly Relational Databases) so
@@ -73,6 +73,6 @@ from current solutions in that:
  
    http://gora.apache.org
  
-#License
+# License
 
 Gora is provided under Apache License version 2.0. See LICENSE.txt for more details.

--- a/gora-maven-plugin/README.md
+++ b/gora-maven-plugin/README.md
@@ -1,22 +1,22 @@
-#Apache Gora Maven Plugin
+# Apache Gora Maven Plugin
 
 The Gora Maven Plugin is used to generate Java sources from Apache Avro *.json schema descriptors.
 The plugin code was originally written by Gerhard Gossen and laterly by Viacheslav Dobromyslov.
 
-##Goals Overview
+## Goals Overview
 
 The Gora Maven Plugin has two goals:
 
 * gora:generate generates Java sources from Apache Avro schema descriptors,
 * gora:help shows usage help.
 
-##Build plugin
+## Build plugin
 
 To build and install plugin on the local machine just run:
     
     mvn clean install
     
-##Usage
+## Usage
 
 Add to your `pom.xml` the following plugin:
     
@@ -38,11 +38,11 @@ And then run:
 
     mvn gora:generate
 
-##Related links
+## Related links
 
 * http://gora.apache.org/current/tutorial.html
 * https://issues.apache.org/jira/browse/GORA-277
 
-###License
+### License
 
 This work is provided under Apache License version 2.0. See LICENSE for more details.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
