### PR TITLE
GORA-512 Add HBase configuration exception for erroneous mapping file and test

### DIFF
--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -73,6 +73,8 @@ import org.jdom.input.SAXBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.naming.ConfigurationException;
+
 /**
  * DataStore for HBase. Thread safe.
  *
@@ -798,8 +800,9 @@ implements Configurable {
           break;
         }
       }
-      if(!keyClassMatches)
-        LOG.error("KeyClass in gora-hbase-mapping is not the same as the one in the databean.");
+      if (!keyClassMatches) {
+        throw new ConfigurationException("Gora-hbase-mapping does not include the name and keyClass in the databean.");
+      }
     } catch (MalformedURLException ex) {
       LOG.error("Error while trying to read the mapping file {}. "
               + "Expected to be in the classpath "

--- a/gora-hbase/src/test/conf/gora-hbase-mapping-mismatch.xml
+++ b/gora-hbase/src/test/conf/gora-hbase-mapping-mismatch.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<gora-otd>
+
+  <table name="Employee"> <!-- optional descriptors for tables -->
+    <family name="info"/> <!-- This can also have params like compression, bloom filters -->
+  </table>
+
+  <table name="WebPage">
+    <family name="common"/>
+    <family name="content"/>
+    <family name="parsedContent"/>
+    <family name="outlinks"/>
+  </table>
+
+  <class name="org.apache.gora.examples.generated.Employee" keyClass="java.lang.String" table="Employee">
+    <field name="name" family="info" qualifier="nm"/>
+    <field name="dateOfBirth" family="info" qualifier="db"/>
+    <field name="ssn" family="info" qualifier="sn"/>
+    <field name="salary" family="info" qualifier="sl"/>
+    <field name="boss" family="info" qualifier="bs"/>
+    <field name="webpage" family="info" qualifier="wp"/>
+  </class>
+
+
+  <class name="org.apache.gora.examples.generated.TokenDatum" keyClass="java.lang.String">
+    <field name="count" family="common" qualifier="count"/>
+  </class>
+
+</gora-otd>

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStore.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStore.java
@@ -25,12 +25,16 @@ import org.apache.gora.hbase.GoraHBaseTestDriver;
 import org.apache.gora.store.DataStore;
 import org.apache.gora.store.DataStoreFactory;
 import org.apache.gora.store.DataStoreTestBase;
+import org.apache.gora.util.GoraException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -227,6 +231,19 @@ public class TestHBaseStore extends DataStoreTestBase {
   public void assertScannerCachingValue() {
     assertEquals(1000, ((HBaseStore<String,WebPage>)this.webPageStore).getScannerCaching()) ;
     assertEquals(1000, ((HBaseStore<String,Employee>)this.employeeStore).getScannerCaching()) ;
+  }
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void assertConfigurationException() throws GoraException {
+    expectedException.expect(GoraException.class);
+    expectedException.expectMessage("Gora-hbase-mapping does not include the name and keyClass in the databean.");
+
+    Configuration exceptionalConf = HBaseConfiguration.create(conf);
+    exceptionalConf.set("gora.hbase.mapping.file","gora-hbase-mapping-mismatch.xml");
+    DataStoreFactory.createDataStore(HBaseStore.class, String.class, WebPage.class, exceptionalConf);
   }
 
 }


### PR DESCRIPTION
This PR resolves GORA-512 by adding the necessary exception for erroneous mapping files and a test case to capture it. 