### PR TITLE
GORA-519 Add support for connecting to authenticated servers in aerospike module

### DIFF
--- a/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeParameters.java
+++ b/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeParameters.java
@@ -33,7 +33,7 @@ public class AerospikeParameters {
 
   private int port;
 
-  private String user;
+  private String username;
 
   private String password;
 
@@ -45,6 +45,10 @@ public class AerospikeParameters {
   private static final String AS_SERVER_IP = "gora.aerospikestore.server.ip";
 
   private static final String AS_SERVER_PORT = "gora.aerospikestore.server.port";
+
+  private static final String AS_SERVER_USERNAME = "gora.aerospikestore.server.username";
+
+  private static final String AS_SERVER_PASSWORD = "gora.aerospikestore.server.password";
 
   // Default property values
   private static final String DEFAULT_SERVER_IP = "localhost";
@@ -63,6 +67,8 @@ public class AerospikeParameters {
     this.aerospikeMapping = aerospikeMapping;
     this.host = properties.getProperty(AS_SERVER_IP, DEFAULT_SERVER_IP);
     this.port = Integer.parseInt(properties.getProperty(AS_SERVER_PORT, DEFAULT_SERVER_PORT));
+    this.username = properties.getProperty(AS_SERVER_USERNAME, null);
+    this.password = properties.getProperty(AS_SERVER_PASSWORD, null);
   }
 
   public String getHost() {
@@ -81,12 +87,12 @@ public class AerospikeParameters {
     this.port = port;
   }
 
-  public String getUser() {
-    return user;
+  public String getUsername() {
+    return username;
   }
 
-  public void setUser(String user) {
-    this.user = user;
+  public void setUsername(String username) {
+    this.username = username;
   }
 
   public String getPassword() {

--- a/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
+++ b/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
@@ -95,6 +95,14 @@ public class AerospikeStore<K, T extends PersistentBase> extends DataStoreBase<K
     policy.readPolicyDefault.sendKey = true;
     policy.writePolicyDefault.sendKey = true;
 
+    // Set the credentials for servers with restricted access
+    if (aerospikeParameters.getUsername() != null) {
+      policy.user = aerospikeParameters.getUsername();
+    }
+    if (aerospikeParameters.getPassword() != null) {
+      policy.password = aerospikeParameters.getPassword();
+    }
+
     aerospikeClient = new AerospikeClient(policy, aerospikeParameters.getHost(),
             aerospikeParameters.getPort());
     aerospikeParameters.setServerSpecificParameters(aerospikeClient);

--- a/gora-tutorial/conf/gora.properties
+++ b/gora-tutorial/conf/gora.properties
@@ -60,3 +60,9 @@ gora.datastore.jcache.provider=com.hazelcast.cache.impl.HazelcastServerCachingPr
 #gora.datastore.jcache.provider=com.hazelcast.client.cache.impl.HazelcastClientCachingProvider
 #gora.datastore.jcache.hazelcast.config=hazelcast-client.xml
 gora.datastore.jcache.hazelcast.config=hazelcast.xml
+
+##Aerospike dataStore properties
+#gora.aerospikestore.server.ip=localhost
+#gora.aerospikestore.server.port=3000
+#gora.aerospikestore.server.username=
+#gora.aerospikestore.server.password=


### PR DESCRIPTION
This PR contains changes to validate against a server that has restricted access with basic authentication. 

Note 
This functionality is not tested as the security enabling can be only done in the [enterprise edition](http://www.aerospike.com/docs/guide/security/index.html) of Aerospike