### PR TITLE
GORA-520 Add support to retrieve partitions in aerospike module

### DIFF
--- a/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
+++ b/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
@@ -45,6 +45,7 @@ import org.apache.gora.persistency.impl.PersistentBase;
 import org.apache.gora.query.PartitionQuery;
 import org.apache.gora.query.Query;
 import org.apache.gora.query.Result;
+import org.apache.gora.query.impl.PartitionQueryImpl;
 import org.apache.gora.store.impl.DataStoreBase;
 import org.apache.gora.util.AvroUtils;
 import org.slf4j.Logger;
@@ -322,11 +323,21 @@ public class AerospikeStore<K, T extends PersistentBase> extends DataStoreBase<K
   }
 
   /**
-   * The functionality is not supported as query key ranges are not supported
+   * {@inheritDoc}
+   * As the Aerospike does not support query key ranges as at the moment, only the single partition
+   * is retrieved with this method.
+   *
+   * @param query the query to execute.
+   * @return the list of partitions, one partion at the list as at the moment
    */
   @Override
   public List<PartitionQuery<K, T>> getPartitions(Query<K, T> query) throws IOException {
-    return null;
+    List<PartitionQuery<K, T>> partitions = new ArrayList<>();
+    PartitionQueryImpl<K, T> partitionQuery = new PartitionQueryImpl<>(
+            query);
+    partitionQuery.setConf(getConf());
+    partitions.add(partitionQuery);
+    return partitions;
   }
 
   @Override

--- a/gora-aerospike/src/test/java/org/apache/gora/aerospike/store/TestAerospikeStore.java
+++ b/gora-aerospike/src/test/java/org/apache/gora/aerospike/store/TestAerospikeStore.java
@@ -61,27 +61,6 @@ public class TestAerospikeStore extends DataStoreTestBase {
   }
 
   @Test
-  @Ignore("Explicit schema creation related functionality is not supported in Aerospike")
-  @Override
-  public void testTruncateSchema() throws Exception {
-    super.testTruncateSchema();
-  }
-
-  @Test
-  @Ignore("Explicit schema creation related functionality is not supported in Aerospike")
-  @Override
-  public void testDeleteSchema() throws Exception {
-    super.testDeleteSchema();
-  }
-
-  @Test
-  @Ignore("Explicit schema creation related functionality is not supported in Aerospike")
-  @Override
-  public void testSchemaExists() throws Exception {
-    super.testSchemaExists();
-  }
-
-  @Test
   @Override
   public void testQuery() throws Exception {
     // Clearing the test data in the database
@@ -91,27 +70,6 @@ public class TestAerospikeStore extends DataStoreTestBase {
     webPageStore.deleteByQuery(query);
 
     super.testQuery();
-  }
-
-  @Test
-  @Ignore("Query key ranges based on primary key is not supported via the java client")
-  @Override
-  public void testQueryStartKey() throws Exception {
-    super.testQueryStartKey();
-  }
-
-  @Test
-  @Ignore("Query key ranges based on primary key is not supported via the java client")
-  @Override
-  public void testQueryEndKey() throws Exception {
-    super.testQueryEndKey();
-  }
-
-  @Test
-  @Ignore("Query key ranges based on primary key is not supported via the java client")
-  @Override
-  public void testQueryKeyRange() throws Exception {
-    super.testQueryKeyRange();
   }
 
   @Test
@@ -156,11 +114,48 @@ public class TestAerospikeStore extends DataStoreTestBase {
     webPageStore.truncateSchema();
   }
 
+  // Unsupported functionality due to the limitations in Aerospike java client
+
   @Test
-  @Ignore("Functionality is to be implemented in the next iteration")
+  @Ignore("Explicit schema creation related functionality is not supported in Aerospike")
   @Override
-  public void testGetPartitions() throws Exception {
-    super.testGetPartitions();
+  public void testTruncateSchema() throws Exception {
+    super.testTruncateSchema();
+  }
+
+  @Test
+  @Ignore("Explicit schema creation related functionality is not supported in Aerospike")
+  @Override
+  public void testDeleteSchema() throws Exception {
+    super.testDeleteSchema();
+  }
+
+  @Test
+  @Ignore("Explicit schema creation related functionality is not supported in Aerospike")
+  @Override
+  public void testSchemaExists() throws Exception {
+    super.testSchemaExists();
+  }
+
+  @Test
+  @Ignore("Query key ranges based on primary key is not supported via the java client")
+  @Override
+  public void testQueryStartKey() throws Exception {
+    super.testQueryStartKey();
+  }
+
+  @Test
+  @Ignore("Query key ranges based on primary key is not supported via the java client")
+  @Override
+  public void testQueryEndKey() throws Exception {
+    super.testQueryEndKey();
+  }
+
+  @Test
+  @Ignore("Query key ranges based on primary key is not supported via the java client")
+  @Override
+  public void testQueryKeyRange() throws Exception {
+    super.testQueryKeyRange();
   }
 
   @Test


### PR DESCRIPTION
This PR contains changes to retrieve the partitions in aerospike module.
As Aerospike does not support query key ranges as at the moment, only the single partition is retrieved with this method. In addition this PR fixes the test case related to getPartitions method and formats the Aerospike test store. 