### PR TITLE
GORA-536: Avoid calling Class#newInstance

### DIFF
--- a/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
+++ b/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
@@ -18,6 +18,7 @@ package org.apache.gora.accumulo.store;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -374,7 +375,7 @@ public class AccumuloStore<K,T extends PersistentBase> extends DataStoreBase<K,T
       if (mapping.encoder == null || "".equals(mapping.encoder)) {
         encoder = new BinaryEncoder();
       } else {
-          encoder = (Encoder) getClass().getClassLoader().loadClass(mapping.encoder).newInstance();
+          encoder = (Encoder) getClass().getClassLoader().loadClass(mapping.encoder).getDeclaredConstructor().newInstance();
       }
 
       AuthenticationToken token = new PasswordToken(password);
@@ -391,7 +392,9 @@ public class AccumuloStore<K,T extends PersistentBase> extends DataStoreBase<K,T
         createSchema();
       
     } catch (IOException | InstantiationException | IllegalAccessException |
-             ClassNotFoundException | AccumuloException | AccumuloSecurityException e) {
+             ClassNotFoundException | AccumuloException | AccumuloSecurityException |
+             NoSuchMethodException | SecurityException | IllegalArgumentException | 
+             InvocationTargetException e) {
       throw new GoraException(e);
     }
   }

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraClient.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraClient.java
@@ -528,7 +528,7 @@ public class CassandraClient {
 
   private void registerCustomCodecs(List<String> codecs) throws Exception {
     for (String codec : codecs) {
-      this.cluster.getConfiguration().getCodecRegistry().register((TypeCodec<?>) Class.forName(codec).newInstance());
+      this.cluster.getConfiguration().getCodecRegistry().register((TypeCodec<?>) Class.forName(codec).getDeclaredConstructor().newInstance());
     }
   }
 

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
@@ -166,7 +166,7 @@ public class CassandraStore<K, T extends Persistent> implements DataStore<K, T> 
       if (beanFactory != null) {
         return beanFactory.newKey();
       } else {
-        return keyClass.newInstance();
+        return keyClass.getDeclaredConstructor().newInstance();
       }
     } catch (Exception e) {
       throw new GoraException("Error while instantiating a key: " + e.getMessage(), e);
@@ -183,7 +183,7 @@ public class CassandraStore<K, T extends Persistent> implements DataStore<K, T> 
       if (beanFactory != null) {
         return this.beanFactory.newPersistent();
       } else {
-        return persistentClass.newInstance();
+        return persistentClass.getDeclaredConstructor().newInstance();
       }
     } catch (Exception e) {
       throw new GoraException("Error while instantiating a key: " + e.getMessage(), e);

--- a/gora-core/src/main/java/org/apache/gora/persistency/impl/BeanFactoryImpl.java
+++ b/gora-core/src/main/java/org/apache/gora/persistency/impl/BeanFactoryImpl.java
@@ -77,7 +77,7 @@ public class BeanFactoryImpl<K, T extends Persistent> implements BeanFactory<K, 
   
   @Override
   public K newKey() throws Exception {
-    return keyClass.newInstance();
+    return keyClass.getDeclaredConstructor().newInstance();
   }
  
   @Override

--- a/gora-core/src/main/java/org/apache/gora/persistency/ws/impl/BeanFactoryWSImpl.java
+++ b/gora-core/src/main/java/org/apache/gora/persistency/ws/impl/BeanFactoryWSImpl.java
@@ -19,6 +19,7 @@
 package org.apache.gora.persistency.ws.impl;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 import org.apache.gora.persistency.BeanFactory;
 import org.apache.gora.persistency.Persistent;
@@ -98,7 +99,7 @@ public class BeanFactoryWSImpl<K, T extends Persistent> implements BeanFactory<K
   public K newKey() throws Exception {
     // TODO this method should be checked to see how object states will be managed
     if(isKeyPersistent)
-      return keyClass.newInstance();
+      return keyClass.getDeclaredConstructor().newInstance();
     else if(keyConstructor == null) {
       throw new RuntimeException("Key class does not have a no-arg constructor");
     }
@@ -112,8 +113,9 @@ public class BeanFactoryWSImpl<K, T extends Persistent> implements BeanFactory<K
    */
   public T newPersistent() {
     try {
-      return persistentClass.newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      return persistentClass.getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException |
+            InvocationTargetException | NoSuchMethodException | SecurityException e) {
       LOG.error(e.getMessage());
       throw new RuntimeException(e);
     }

--- a/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBNativeStore.java
+++ b/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBNativeStore.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.lang.NullArgumentException;
 import org.apache.gora.dynamodb.query.DynamoDBKey;
 import org.apache.gora.dynamodb.query.DynamoDBQuery;
 import org.apache.gora.dynamodb.query.DynamoDBResult;
@@ -191,11 +190,14 @@ public class DynamoDBNativeStore<K, T extends Persistent> extends
   public T newPersistent() throws GoraException {
     T obj = null;
     try {
-      obj = persistentClass.newInstance();
+      obj = persistentClass.getDeclaredConstructor().newInstance();
     } catch (InstantiationException e) {
       LOG.error("Error instantiating " + persistentClass.getCanonicalName(), e);
       throw new GoraException(e);
     } catch (IllegalAccessException e) {
+      LOG.error("Error instantiating " + persistentClass.getCanonicalName(),e );
+      throw new GoraException(e);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalArgumentException | SecurityException e) {
       LOG.error("Error instantiating " + persistentClass.getCanonicalName(),e );
       throw new GoraException(e);
     }

--- a/gora-goraci/src/main/java/org/apache/gora/goraci/chef/ChefSoftwareProvisioning.java
+++ b/gora-goraci/src/main/java/org/apache/gora/goraci/chef/ChefSoftwareProvisioning.java
@@ -51,6 +51,7 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
 import com.google.inject.Module;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  *This class contains all of the Chef software provisioning code required to
@@ -80,15 +81,17 @@ public class ChefSoftwareProvisioning {
   public ChefSoftwareProvisioning() {
   }
   
-  private static void performChefComputeServiceBootstrapping(Properties properties) throws IOException, InstantiationException, IllegalAccessException {
+  private static void performChefComputeServiceBootstrapping(Properties properties) throws 
+          IOException, InstantiationException, IllegalAccessException, 
+          NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
     // Get the credentials that will be used to authenticate to the Chef server
-    String rsContinent = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), 
+    String rsContinent = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), 
         RS_CONTINENT, "rackspace-cloudservers-us");
-    String rsUser = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_USERNAME, "asf-gora");
-    String rsApiKey = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_APIKEY, null);
-    String rsRegion = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_REGION, "DFW");
-    String client = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), CHEF_CLIENT, System.getProperty("user.name"));
-    String organization = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), CHEF_ORGANIZATION, null);
+    String rsUser = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_USERNAME, "asf-gora");
+    String rsApiKey = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_APIKEY, null);
+    String rsRegion = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_REGION, "DFW");
+    String client = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), CHEF_CLIENT, System.getProperty("user.name"));
+    String organization = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), CHEF_ORGANIZATION, null);
     String pemFile = System.getProperty("user.home") + "/.chef/" + client + ".pem";
     String credential = Files.toString(new File(pemFile), Charsets.UTF_8);
 
@@ -169,7 +172,7 @@ public class ChefSoftwareProvisioning {
    * @throws IllegalAccessException 
    * @throws InstantiationException 
    */
-  public static void main(String[] args) throws InstantiationException, IllegalAccessException, IOException {
+  public static void main(String[] args) throws InstantiationException, IllegalAccessException, IOException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
     Properties props = DataStoreFactory.createProps();
     ChefSoftwareProvisioning.performChefComputeServiceBootstrapping(props);
   }

--- a/gora-goraci/src/main/java/org/apache/gora/goraci/rackspace/RackspaceOrchestration.java
+++ b/gora-goraci/src/main/java/org/apache/gora/goraci/rackspace/RackspaceOrchestration.java
@@ -59,6 +59,7 @@ import com.google.inject.Module;
 
 import static com.google.common.collect.Iterables.any;
 import static com.google.common.collect.Iterables.concat;
+import java.lang.reflect.InvocationTargetException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,22 +117,26 @@ public class RackspaceOrchestration<K> {
    * @throws IllegalAccessException 
    * @throws InstantiationException 
    * @throws NoSuchElementException 
+   * @throws java.io.IOException 
+   * @throws java.lang.NoSuchMethodException 
+   * @throws java.lang.reflect.InvocationTargetException 
    */
-  public static void main(String[] args) throws NoSuchElementException, InstantiationException, IllegalAccessException, IOException {
+  public static void main(String[] args) throws NoSuchElementException, InstantiationException, IllegalAccessException, IOException, NoSuchMethodException, InvocationTargetException {
     Properties properties = DataStoreFactory.createProps();
     performRackspaceOrchestration(properties);
   }
   
-  private static void performRackspaceOrchestration(Properties properties) throws InstantiationException, IllegalAccessException, IOException {
-    rsContinent = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), 
+  private static void performRackspaceOrchestration(Properties properties) throws InstantiationException, 
+          IllegalAccessException, IOException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
+    rsContinent = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), 
         RS_CONTINENT, "rackspace-cloudservers-us");
-    rsUser = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_USERNAME, "asf-gora");
-    rsApiKey = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_APIKEY, null);
-    rsRegion = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_REGION, "DFW");
-    String rsFlavourId = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_FLAVORID, null);
-    String rsImageId = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_IMAGEID, null);
-    int numServers = Integer.parseInt(DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_NUM_SERVERS, "10"));
-    String serverName = DataStoreFactory.findProperty(properties, MemStore.class.newInstance(), RS_SERVERNAME, "goraci_test_server");
+    rsUser = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_USERNAME, "asf-gora");
+    rsApiKey = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_APIKEY, null);
+    rsRegion = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_REGION, "DFW");
+    String rsFlavourId = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_FLAVORID, null);
+    String rsImageId = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_IMAGEID, null);
+    int numServers = Integer.parseInt(DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_NUM_SERVERS, "10"));
+    String serverName = DataStoreFactory.findProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_SERVERNAME, "goraci_test_server");
 
     novaApi = ContextBuilder.newBuilder(rsContinent).credentials(rsUser, rsApiKey).buildApi(NovaApi.class);
     LOG.info("Defining Rackspace cloudserver continent as: {}, and region: {}.", rsContinent, rsRegion);
@@ -150,7 +155,7 @@ public class RackspaceOrchestration<K> {
     File keyPairFile = null;
     String publicKey = null;
     //Use your own .pub key which should be on CP
-    if (DataStoreFactory.findBooleanProperty(properties, MemStore.class.newInstance(), RS_PUBKEY, "true")) {
+    if (DataStoreFactory.findBooleanProperty(properties, MemStore.class.getDeclaredConstructor().newInstance(), RS_PUBKEY, "true")) {
       keyPairFile = new File("~/.ssh/id_rsa.pub");
       LOG.info("Uploading local public key from ~/.ssh/id_rsa.pub to Rackspace...");
     } else {

--- a/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanClient.java
+++ b/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanClient.java
@@ -96,7 +96,7 @@ public class InfinispanClient<K, T extends PersistentBase> implements Configurab
 
   public synchronized void createSchema() throws GoraException {
     try {
-      Support.registerSchema(cacheManager, persistentClass.newInstance().getSchema());
+      Support.registerSchema(cacheManager, persistentClass.getConstructor().newInstance().getSchema());
     } catch (Exception e) {
       throw new GoraException(e);
     }

--- a/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanStore.java
+++ b/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanStore.java
@@ -91,7 +91,7 @@ public class InfinispanStore<K, T extends PersistentBase> extends DataStoreBase<
           + keyClass.getCanonicalName()
           + ", persistent class: "
           + persistentClass.getCanonicalName());
-      schema = persistentClass.newInstance().getSchema();
+      schema = persistentClass.getDeclaredConstructor().newInstance().getSchema();
 
       splitSize = Integer.valueOf(
           properties.getProperty( BUFFER_LIMIT_READ_NAME,


### PR DESCRIPTION
When using reflexion use `getDeclaredConstructor().newInstance()` instead of `Class::newInstance` because it may throw undeclared checked exceptions.