### PR TITLE
GORA-534 Upgrade HBase to 2.1.1

### DIFF
--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseMapping.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseMapping.java
@@ -21,9 +21,12 @@ package org.apache.gora.hbase.store;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder.ModifyableColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.io.compress.Compression.Algorithm;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -34,12 +37,12 @@ import org.apache.hadoop.hbase.util.Bytes;
  */
 public class HBaseMapping {
 
-  private final HTableDescriptor tableDescriptor;
+  private final TableDescriptor tableDescriptor;
   
   // a map from field name to hbase column
   private final Map<String, HBaseColumn> columnMap;
   
-  public HBaseMapping(HTableDescriptor tableDescriptor,
+  public HBaseMapping(TableDescriptor tableDescriptor,
       Map<String, HBaseColumn> columnMap) {
     super();
     this.tableDescriptor = tableDescriptor;
@@ -48,10 +51,10 @@ public class HBaseMapping {
   
 
   public String getTableName() {
-    return tableDescriptor.getNameAsString();
+    return tableDescriptor.getTableName().getNameAsString();
   }
   
-  public HTableDescriptor getTable() {
+  public TableDescriptor getTable() {
     return tableDescriptor;
   }
   
@@ -65,7 +68,7 @@ public class HBaseMapping {
    *
    */
   public static class HBaseMappingBuilder { 
-    private Map<String, Map<String, HColumnDescriptor>> tableToFamilies = 
+    private Map<String, Map<String, ColumnFamilyDescriptor>> tableToFamilies =
       new HashMap<>();
     private Map<String, HBaseColumn> columnMap = 
       new HashMap<>();
@@ -98,29 +101,30 @@ public class HBaseMapping {
       // For example nest columns in families. Of course this would break compatibility.
       
       
-      Map<String, HColumnDescriptor> families = getOrCreateFamilies(tableName);
-      
-      
-      HColumnDescriptor columnDescriptor = getOrCreateFamily(familyName, families);
+      Map<String, ColumnFamilyDescriptor> families = getOrCreateFamilies(tableName);
+
+      ColumnFamilyDescriptor columnDescriptor = getOrCreateFamily(familyName, families);
+      ModifyableColumnFamilyDescriptor modifyableColFamilyDescriptor =
+              (ModifyableColumnFamilyDescriptor) columnDescriptor;
       
       if(compression != null)
-        columnDescriptor.setCompressionType(Algorithm.valueOf(compression));
+        modifyableColFamilyDescriptor.setCompressionType(Algorithm.valueOf(compression));
       if(blockCache != null)
-        columnDescriptor.setBlockCacheEnabled(Boolean.parseBoolean(blockCache));
+        modifyableColFamilyDescriptor.setBlockCacheEnabled(Boolean.parseBoolean(blockCache));
       if(blockSize != null)
-        columnDescriptor.setBlocksize(Integer.parseInt(blockSize));
+        modifyableColFamilyDescriptor.setBlocksize(Integer.parseInt(blockSize));
       if(bloomFilter != null)
-        columnDescriptor.setBloomFilterType(BloomType.valueOf(bloomFilter));
+        modifyableColFamilyDescriptor.setBloomFilterType(BloomType.valueOf(bloomFilter));
       if(maxVersions != null)
-        columnDescriptor.setMaxVersions(Integer.parseInt(maxVersions));
+        modifyableColFamilyDescriptor.setMaxVersions(Integer.parseInt(maxVersions));
       if(timeToLive != null)
-        columnDescriptor.setTimeToLive(Integer.parseInt(timeToLive));
+        modifyableColFamilyDescriptor.setTimeToLive(Integer.parseInt(timeToLive));
       if(inMemory != null)
-        columnDescriptor.setInMemory(Boolean.parseBoolean(inMemory));
+        modifyableColFamilyDescriptor.setInMemory(Boolean.parseBoolean(inMemory));
     }
 
     public void addColumnFamily(String tableName, String familyName) {
-      Map<String, HColumnDescriptor> families = getOrCreateFamilies(tableName);
+      Map<String, ColumnFamilyDescriptor> families = getOrCreateFamilies(tableName);
       getOrCreateFamily(familyName, families);
     }
     
@@ -132,20 +136,22 @@ public class HBaseMapping {
       HBaseColumn column = new HBaseColumn(familyBytes, qualifierBytes);
       columnMap.put(fieldName, column);
     }
-    
 
-    private HColumnDescriptor getOrCreateFamily(String familyName,
-        Map<String, HColumnDescriptor> families) {
-      HColumnDescriptor columnDescriptor = families.get(familyName);
+
+    private ColumnFamilyDescriptor getOrCreateFamily(String familyName,
+                                                     Map<String, ColumnFamilyDescriptor> families) {
+      ColumnFamilyDescriptor columnDescriptor = families.get(familyName);
       if (columnDescriptor == null) {
-        columnDescriptor=new HColumnDescriptor(familyName);
+        ColumnFamilyDescriptorBuilder columnDescBuilder = ColumnFamilyDescriptorBuilder
+                .newBuilder(Bytes.toBytes(familyName));
+        columnDescriptor = columnDescBuilder.build();
         families.put(familyName, columnDescriptor);
       }
       return columnDescriptor;
     }
 
-    private Map<String, HColumnDescriptor> getOrCreateFamilies(String tableName) {
-      Map<String, HColumnDescriptor> families;
+    private Map<String, ColumnFamilyDescriptor> getOrCreateFamilies(String tableName) {
+      Map<String, ColumnFamilyDescriptor> families;
       families = tableToFamilies.get(tableName);
       if (families == null) {
         families = new HashMap<>();
@@ -155,7 +161,7 @@ public class HBaseMapping {
     }
     
     public void renameTable(String oldName, String newName) {
-      Map<String, HColumnDescriptor> families = tableToFamilies.remove(oldName);
+      Map<String, ColumnFamilyDescriptor> families = tableToFamilies.remove(oldName);
       if (families == null) throw new IllegalArgumentException(oldName + " does not exist");
       tableToFamilies.put(newName, families);
     }
@@ -165,15 +171,17 @@ public class HBaseMapping {
      */
     public HBaseMapping build() {
       if (tableName == null) throw new IllegalStateException("tableName is not specified");
-      
-      Map<String, HColumnDescriptor> families = tableToFamilies.get(tableName.getNameAsString());
+
+      Map<String, ColumnFamilyDescriptor> families = tableToFamilies.get(tableName.getNameAsString());
       if (families == null) throw new IllegalStateException("no families for table " + tableName);
-      
-      HTableDescriptor tableDescriptors = new HTableDescriptor(tableName);
-      for (HColumnDescriptor desc : families.values()) {
-        tableDescriptors.addFamily(desc);
+
+      TableDescriptorBuilder tableDescBuilder = TableDescriptorBuilder.newBuilder(tableName);
+
+      for (ColumnFamilyDescriptor familyDescriptor : families.values()) {
+        tableDescBuilder.setColumnFamily(familyDescriptor);
       }
-      return new HBaseMapping(tableDescriptors, columnMap);
+      TableDescriptor tableDescriptor = tableDescBuilder.build();
+      return new HBaseMapping(tableDescriptor, columnMap);
     }
   }
 

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -59,11 +59,11 @@ import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -177,7 +177,7 @@ implements Configurable {
       if(schemaExists()) {
         return;
       }
-      HTableDescriptor tableDesc = mapping.getTable();
+      TableDescriptor tableDesc = mapping.getTable();
   
       admin.createTable(tableDesc);
     } catch (GoraException e) {
@@ -490,14 +490,12 @@ implements Configurable {
     scan.setCaching(this.getScannerCaching()) ; 
     
     if (query.getStartKey() != null) {
-      scan.setStartRow(toBytes(query.getStartKey()));
+      scan.withStartRow(toBytes(query.getStartKey()));
     }
     if (query.getEndKey() != null) {
-      // In HBase the end key is exclusive, so we add a trail zero to make it inclusive
-      // as the Gora's query interface declares.
-      byte[] endKey = toBytes(query.getEndKey());
-      byte[] inclusiveEndKey = Arrays.copyOf(endKey, endKey.length+1);
-      scan.setStopRow(inclusiveEndKey);
+      // In HBase the end key is exclusive, so we make it inclusive by explicitly passing
+      // boolean 'true' as the Gora's query interface declares.
+      scan.withStopRow(toBytes(query.getEndKey()), true);
     }
     addFields(scan, query);
     if (query.getFilter() != null) {

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseTableConnection.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseTableConnection.java
@@ -154,8 +154,8 @@ public class HBaseTableConnection {
     return getTable().exists(get);
   }
 
-  public boolean[] existsAll(List<Get> list) throws IOException {
-    return getTable().existsAll(list);
+  public boolean[] exists(List<Get> list) throws IOException {
+    return getTable().exists(list);
   }
 
   public Result get(Get get) throws IOException {

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/util/DefaultFactory.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/util/DefaultFactory.java
@@ -28,7 +28,7 @@ import org.apache.gora.filter.SingleFieldValueFilter;
 import org.apache.gora.hbase.store.HBaseColumn;
 import org.apache.gora.hbase.store.HBaseStore;
 import org.apache.gora.persistency.impl.PersistentBase;
-import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
+import org.apache.hadoop.hbase.CompareOperator;
 import org.apache.hadoop.hbase.filter.FilterList.Operator;
 import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
 
@@ -69,7 +69,7 @@ public class DefaultFactory <K, T extends PersistentBase> extends BaseFactory<K,
       SingleFieldValueFilter<K, T> fieldFilter = (SingleFieldValueFilter<K, T>) filter;
 
       HBaseColumn column = store.getMapping().getColumn(fieldFilter.getFieldName());
-      CompareOp compareOp = getCompareOp(fieldFilter.getFilterOp());
+      CompareOperator compareOp = getCompareOp(fieldFilter.getFilterOp());
       byte[] family = column.getFamily();
       byte[] qualifier = column.getQualifier();
       byte[] value = HBaseByteInterface.toBytes(fieldFilter.getOperands().get(0));
@@ -81,7 +81,7 @@ public class DefaultFactory <K, T extends PersistentBase> extends BaseFactory<K,
       MapFieldValueFilter<K, T> mapFilter = (MapFieldValueFilter<K, T>) filter;
 
       HBaseColumn column = store.getMapping().getColumn(mapFilter.getFieldName());
-      CompareOp compareOp = getCompareOp(mapFilter.getFilterOp());
+      CompareOperator compareOp = getCompareOp(mapFilter.getFilterOp());
       byte[] family = column.getFamily();
       byte[] qualifier = HBaseByteInterface.toBytes(mapFilter.getMapKey());
       byte[] value = HBaseByteInterface.toBytes(mapFilter.getOperands().get(0));
@@ -95,20 +95,20 @@ public class DefaultFactory <K, T extends PersistentBase> extends BaseFactory<K,
     }
   }
 
-  private CompareOp getCompareOp(FilterOp filterOp) {
+  private CompareOperator getCompareOp(FilterOp filterOp) {
     switch (filterOp) {
       case EQUALS:
-        return CompareOp.EQUAL;
+        return CompareOperator.EQUAL;
       case NOT_EQUALS:
-        return CompareOp.NOT_EQUAL;
+        return CompareOperator.NOT_EQUAL;
       case LESS:
-        return CompareOp.LESS;
+        return CompareOperator.LESS;
       case LESS_OR_EQUAL:
-        return CompareOp.LESS_OR_EQUAL;
+        return CompareOperator.LESS_OR_EQUAL;
       case GREATER:
-        return CompareOp.GREATER;
+        return CompareOperator.GREATER;
       case GREATER_OR_EQUAL:
-        return CompareOp.GREATER_OR_EQUAL;
+        return CompareOperator.GREATER_OR_EQUAL;
       default:
         throw new IllegalArgumentException(filterOp + " no HBase equivalent yet");
     }

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStore.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStore.java
@@ -22,14 +22,17 @@ import org.apache.avro.util.Utf8;
 import org.apache.gora.examples.generated.Employee;
 import org.apache.gora.examples.generated.WebPage;
 import org.apache.gora.hbase.GoraHBaseTestDriver;
-import org.apache.gora.store.DataStore;
 import org.apache.gora.store.DataStoreFactory;
 import org.apache.gora.store.DataStoreTestBase;
 import org.apache.gora.util.GoraException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -69,8 +72,8 @@ public class TestHBaseStore extends DataStoreTestBase {
 
   @Override
   public void assertSchemaExists(String schemaName) throws Exception {
-    HBaseAdmin admin = getTestDriver().getHbaseUtil().getHBaseAdmin();
-    assertTrue("Table should exist for...", admin.tableExists(schemaName));
+    Admin admin = getTestDriver().getHbaseUtil().getAdmin();
+    assertTrue("Table should exist for...", admin.tableExists(TableName.valueOf(schemaName)));
   }
 
   @Override
@@ -141,7 +144,7 @@ public class TestHBaseStore extends DataStoreTestBase {
     // Check directly with HBase
 
 
-    table = new HTable(conf,"WebPage");
+    table = conn.getTable(TableName.valueOf("WebPage"));
     get = new Get(Bytes.toBytes("com.example/http"));
     result = table.get(get);
     actualBytes = result.getValue(Bytes.toBytes("content"), null);
@@ -168,7 +171,8 @@ public class TestHBaseStore extends DataStoreTestBase {
     webPageStore.flush() ;
     
     // Read directly from HBase
-    HTable table = new HTable(conf,"WebPage");
+    Connection conn = ConnectionFactory.createConnection(conf);
+    Table table = conn.getTable(TableName.valueOf("WebPage"));
     Get get = new Get(Bytes.toBytes("com.example/http"));
     org.apache.hadoop.hbase.client.Result result = table.get(get);
 

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/util/HBaseClusterSingleton.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/util/HBaseClusterSingleton.java
@@ -24,10 +24,11 @@ import java.nio.charset.Charset;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.MiniHBaseCluster;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,9 +152,9 @@ public final class HBaseClusterSingleton {
    * @throws IOException
    */
   public void ensureTable(byte[] tableName, byte[][] cfs) throws IOException {
-    HBaseAdmin admin = htu.getHBaseAdmin();
-    if (!admin.tableExists(tableName)) {
-      HTable hTable = htu.createTable(tableName, cfs);
+    Admin admin = htu.getAdmin();
+    if (!admin.tableExists(TableName.valueOf(tableName))) {
+      Table hTable = htu.createTable(TableName.valueOf(tableName), cfs);
       hTable.close();
     }
   }
@@ -163,9 +164,9 @@ public final class HBaseClusterSingleton {
    * @throws Exception
    */
   public void truncateAllTables() throws Exception {
-    HBaseAdmin admin = htu.getHBaseAdmin();
-    for(HTableDescriptor table:admin.listTables()) {
-      HTable hTable = htu.deleteTableData(table.getName());
+    Admin admin = htu.getAdmin();
+    for(TableDescriptor table:admin.listTableDescriptors()) {
+      Table hTable = htu.deleteTableData(table.getTableName());
       hTable.close();
     }
   }
@@ -176,10 +177,10 @@ public final class HBaseClusterSingleton {
    * @throws Exception
    */
   public void deleteAllTables() throws Exception {
-    HBaseAdmin admin = htu.getHBaseAdmin();
-    for(HTableDescriptor table:admin.listTables()) {
-      admin.disableTable(table.getName());
-      admin.deleteTable(table.getName());
+    Admin admin = htu.getAdmin();
+    for(TableDescriptor table:admin.listTableDescriptors()) {
+      admin.disableTable(table.getTableName());
+      admin.deleteTable(table.getTableName());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -772,8 +772,8 @@
     <!-- Hadoop Dependencies -->
     <hadoop-2.version>2.5.2</hadoop-2.version>
     <hadoop-2.test.version>2.5.2</hadoop-2.test.version>
-    <hbase.version>1.2.6</hbase.version>
-    <hbase.test.version>1.2.6</hbase.test.version>
+    <hbase.version>2.1.1</hbase.version>
+    <hbase.test.version>2.1.1</hbase.test.version>
     <cxf-rt-frontend-jaxrs.version>2.5.2</cxf-rt-frontend-jaxrs.version>
     <!-- Amazon Dependencies -->
     <amazon.version>1.10.55</amazon.version>


### PR DESCRIPTION
This PR includes HBase Version upgrade to 2.1.1. I have also avoided all the deprecated methods usages.
I went thought PR https://github.com/apache/gora/pull/86 and I guess we need check whether we can get rid of changes introduced by https://github.com/apache/gora/pull/95 after issue https://issues.apache.org/jira/browse/HBASE-8770 is fixed from HBase.

