### PR TITLE
GORA-550: Update POM on the move to gitbox.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,9 +315,9 @@
   </mailingLists>
 
   <scm>
-    <connection>scm:git:http://git-wip-us.apache.org/repos/asf/gora.git</connection>
-    <developerConnection>scm:git:http://git-wip-us.apache.org/repos/asf/gora.git</developerConnection>
-    <url>https://git-wip-us.apache.org/repos/asf/gora.git</url>
+    <connection>scm:git:http://gitbox.apache.org/repos/asf/gora.git</connection>
+    <developerConnection>scm:git:http://gitbox.apache.org/repos/asf/gora.git</developerConnection>
+    <url>https://gitbox.apache.org/repos/asf/gora.git</url>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>


### PR DESCRIPTION
Update <scm> section for parent pom after the move to gitbox.apache.org.