### PR TITLE
GORA 411 - Add exists(key) to DataStore interface

### DIFF
--- a/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
+++ b/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
@@ -642,16 +642,15 @@ public class AccumuloStore<K,T extends PersistentBase> extends DataStoreBase<K,T
       }
     }
   }
-	
-	@Override
+
+  @Override
   public boolean exists(K key) throws GoraException {
     try {
-      // TODO make isolated scanner optional?
       Scanner scanner = new IsolatedScanner(conn.createScanner(mapping.tableName, Authorizations.EMPTY));
       Range rowRange = new Range(new Text(toBytes(key)));
       scanner.setRange(rowRange);
-			scanner.clearColumns();
-			return scanner.iterator().hasNext();
+      scanner.clearColumns();
+      return scanner.iterator().hasNext();
     } catch (Exception e) {
       throw new GoraException(e);
     }

--- a/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
+++ b/gora-accumulo/src/main/java/org/apache/gora/accumulo/store/AccumuloStore.java
@@ -642,6 +642,20 @@ public class AccumuloStore<K,T extends PersistentBase> extends DataStoreBase<K,T
       }
     }
   }
+	
+	@Override
+  public boolean exists(K key) throws GoraException {
+    try {
+      // TODO make isolated scanner optional?
+      Scanner scanner = new IsolatedScanner(conn.createScanner(mapping.tableName, Authorizations.EMPTY));
+      Range rowRange = new Range(new Text(toBytes(key)));
+      scanner.setRange(rowRange);
+			scanner.clearColumns();
+			return scanner.iterator().hasNext();
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
   @Override
   public T get(K key, String[] fields) throws GoraException {

--- a/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
+++ b/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
@@ -185,16 +185,16 @@ public class AerospikeStore<K, T extends PersistentBase> extends DataStoreBase<K
       throw new GoraException(e);
     }
   }
-	
-	@Override
-	public boolean exists(K key) throws GoraException {
-		try {
-			Key recordKey = getAerospikeKey(key);
-			return aerospikeClient.exists(aerospikeParameters.getAerospikeMapping().getReadPolicy(), recordKey);
-		} catch (Exception e) {
-			throw new GoraException(e);
-		}
-	}
+
+  @Override
+  public boolean exists(K key) throws GoraException {
+    try {
+      Key recordKey = getAerospikeKey(key);
+      return aerospikeClient.exists(aerospikeParameters.getAerospikeMapping().getReadPolicy(), recordKey);
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
   /**
    * Method to insert the persistent objects with the given key to the aerospike database server.

--- a/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
+++ b/gora-aerospike/src/main/java/org/apache/gora/aerospike/store/AerospikeStore.java
@@ -185,6 +185,16 @@ public class AerospikeStore<K, T extends PersistentBase> extends DataStoreBase<K
       throw new GoraException(e);
     }
   }
+	
+	@Override
+	public boolean exists(K key) throws GoraException {
+		try {
+			Key recordKey = getAerospikeKey(key);
+			return aerospikeClient.exists(aerospikeParameters.getAerospikeMapping().getReadPolicy(), recordKey);
+		} catch (Exception e) {
+			throw new GoraException(e);
+		}
+	}
 
   /**
    * Method to insert the persistent objects with the given key to the aerospike database server.

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/AvroSerializer.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/AvroSerializer.java
@@ -466,25 +466,25 @@ class AvroSerializer<K, T extends PersistentBase> extends CassandraSerializer {
     }
   }
 
-	@Override
-	public boolean exists(Object key) throws GoraException {
-		try {
-			ArrayList<String> cassandraKeys = new ArrayList<>();
-			ArrayList<Object> cassandraValues = new ArrayList<>();
-			AvroCassandraUtils.processKeys(mapping, key, cassandraKeys, cassandraValues);
-			String cqlQuery = CassandraQueryFactory.getCheckExistsQuery(mapping, cassandraKeys);
-			SimpleStatement statement = new SimpleStatement(cqlQuery, cassandraValues.toArray());
-			if (readConsistencyLevel != null) {
-				statement.setConsistencyLevel(ConsistencyLevel.valueOf(readConsistencyLevel));
-			}
-			ResultSet resultSet = client.getSession().execute(statement);
-			Iterator<Row> iterator = resultSet.iterator();
-			Row next = iterator.next();
-			long aInt = next.getLong(0);
-			return aInt != 0;
-		} catch (Exception e) {
-			throw new GoraException(e);
-		}
-	}
+  @Override
+  public boolean exists(Object key) throws GoraException {
+    try {
+      ArrayList<String> cassandraKeys = new ArrayList<>();
+      ArrayList<Object> cassandraValues = new ArrayList<>();
+      AvroCassandraUtils.processKeys(mapping, key, cassandraKeys, cassandraValues);
+      String cqlQuery = CassandraQueryFactory.getCheckExistsQuery(mapping, cassandraKeys);
+      SimpleStatement statement = new SimpleStatement(cqlQuery, cassandraValues.toArray());
+      if (readConsistencyLevel != null) {
+        statement.setConsistencyLevel(ConsistencyLevel.valueOf(readConsistencyLevel));
+      }
+      ResultSet resultSet = client.getSession().execute(statement);
+      Iterator<Row> iterator = resultSet.iterator();
+      Row next = iterator.next();
+      long aInt = next.getLong(0);
+      return aInt != 0;
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
 }

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraQueryFactory.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraQueryFactory.java
@@ -313,6 +313,24 @@ class CassandraQueryFactory {
     String[] columnNames = getColumnNames(mapping, keyFields);
     return processKeys(columnNames, select);
   }
+	
+	  /**
+   * This method returns CQL Select query to check if a key exists.
+   * This method is used for Avro Serialization
+   * refer: http://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlSelect.html
+   *
+   * @param mapping   Cassandra Mapping {@link CassandraMapping}
+   * @param keyFields key fields
+   * @return CQL Query
+   */
+  static String getCheckExistsQuery(CassandraMapping mapping, List<String> keyFields) {
+    Select select = QueryBuilder.select().countAll().from(mapping.getKeySpace().getName(), mapping.getCoreName());
+    if (Boolean.parseBoolean(mapping.getProperty("allowFiltering"))) {
+      select.allowFiltering();
+    }
+    String[] columnNames = getColumnNames(mapping, keyFields);
+    return processKeys(columnNames, select);
+  }
 
   /**
    * This method returns CQL Select query to retrieve data from the table with given fields.

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraQueryFactory.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraQueryFactory.java
@@ -313,13 +313,13 @@ class CassandraQueryFactory {
     String[] columnNames = getColumnNames(mapping, keyFields);
     return processKeys(columnNames, select);
   }
-	
-	  /**
-   * This method returns CQL Select query to check if a key exists.
-   * This method is used for Avro Serialization
-   * refer: http://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlSelect.html
+
+  /**
+   * This method returns CQL Select query to check if a key exists. This method
+   * is used for Avro Serialization refer:
+   * http://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlSelect.html
    *
-   * @param mapping   Cassandra Mapping {@link CassandraMapping}
+   * @param mapping Cassandra Mapping {@link CassandraMapping}
    * @param keyFields key fields
    * @return CQL Query
    */

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraSerializer.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraSerializer.java
@@ -180,7 +180,7 @@ public abstract class CassandraSerializer<K, T extends Persistent> {
    */
   public abstract T get(K key) throws GoraException;
 	
-	/**
+  /**
    * Check if key exists
    *
    * @param key key value

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraSerializer.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/CassandraSerializer.java
@@ -179,6 +179,14 @@ public abstract class CassandraSerializer<K, T extends Persistent> {
    * @return persistent value
    */
   public abstract T get(K key) throws GoraException;
+	
+	/**
+   * Check if key exists
+   *
+   * @param key key value
+   * @return true/false
+   */
+  public abstract boolean exists(K key) throws GoraException;
 
   /**
    * Deletes persistent value according to the key

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/NativeSerializer.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/NativeSerializer.java
@@ -260,24 +260,25 @@ class NativeSerializer<K, T extends Persistent> extends CassandraSerializer {
     return key;
   }
 
-	@Override
-	public boolean exists(Object key) throws GoraException {
-		try {
-			ArrayList<String> cassandraKeys = new ArrayList<>();
-			ArrayList<Object> cassandraValues = new ArrayList<>();
-			AvroCassandraUtils.processKeys(mapping, key, cassandraKeys, cassandraValues);
-			String cqlQuery = CassandraQueryFactory.getCheckExistsQuery(mapping, cassandraKeys);
-			SimpleStatement statement = new SimpleStatement(cqlQuery, cassandraValues.toArray());
-			if (readConsistencyLevel != null) {
-				statement.setConsistencyLevel(ConsistencyLevel.valueOf(readConsistencyLevel));
-			}
-			ResultSet resultSet = client.getSession().execute(statement);
-			Iterator<Row> iterator = resultSet.iterator();
-			Row next = iterator.next();
-			long aInt = next.getLong(0);
-			return aInt != 0;
-		} catch (Exception e) {
-			throw new GoraException(e);
-		}
-	}
+  @Override
+  public boolean exists(Object key) throws GoraException {
+    try {
+      ArrayList<String> cassandraKeys = new ArrayList<>();
+      ArrayList<Object> cassandraValues = new ArrayList<>();
+      AvroCassandraUtils.processKeys(mapping, key, cassandraKeys, cassandraValues);
+      String cqlQuery = CassandraQueryFactory.getCheckExistsQuery(mapping, cassandraKeys);
+      SimpleStatement statement = new SimpleStatement(cqlQuery, cassandraValues.toArray());
+      if (readConsistencyLevel != null) {
+        statement.setConsistencyLevel(ConsistencyLevel.valueOf(readConsistencyLevel));
+      }
+      ResultSet resultSet = client.getSession().execute(statement);
+      Iterator<Row> iterator = resultSet.iterator();
+      Row next = iterator.next();
+      long aInt = next.getLong(0);
+      return aInt != 0;
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
+
 }

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/NativeSerializer.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/serializers/NativeSerializer.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
@@ -258,4 +259,25 @@ class NativeSerializer<K, T extends Persistent> extends CassandraSerializer {
     }
     return key;
   }
+
+	@Override
+	public boolean exists(Object key) throws GoraException {
+		try {
+			ArrayList<String> cassandraKeys = new ArrayList<>();
+			ArrayList<Object> cassandraValues = new ArrayList<>();
+			AvroCassandraUtils.processKeys(mapping, key, cassandraKeys, cassandraValues);
+			String cqlQuery = CassandraQueryFactory.getCheckExistsQuery(mapping, cassandraKeys);
+			SimpleStatement statement = new SimpleStatement(cqlQuery, cassandraValues.toArray());
+			if (readConsistencyLevel != null) {
+				statement.setConsistencyLevel(ConsistencyLevel.valueOf(readConsistencyLevel));
+			}
+			ResultSet resultSet = client.getSession().execute(statement);
+			Iterator<Row> iterator = resultSet.iterator();
+			Row next = iterator.next();
+			long aInt = next.getLong(0);
+			return aInt != 0;
+		} catch (Exception e) {
+			throw new GoraException(e);
+		}
+	}
 }

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
@@ -333,10 +333,10 @@ public class CassandraStore<K, T extends Persistent> implements DataStore<K, T> 
     return cassandraSerializer.schemaExists();
   }
 
-	@Override
-	public boolean exists(K key) throws GoraException {
-		return cassandraSerializer.exists(key);
-	}
+  @Override
+  public boolean exists(K key) throws GoraException {
+    return cassandraSerializer.exists(key);
+  }
 
   public enum SerializerType {
     AVRO("AVRO"), NATIVE("NATIVE");

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStore.java
@@ -333,6 +333,11 @@ public class CassandraStore<K, T extends Persistent> implements DataStore<K, T> 
     return cassandraSerializer.schemaExists();
   }
 
+	@Override
+	public boolean exists(K key) throws GoraException {
+		return cassandraSerializer.exists(key);
+	}
+
   public enum SerializerType {
     AVRO("AVRO"), NATIVE("NATIVE");
     String val;

--- a/gora-core/src/main/java/org/apache/gora/avro/store/AvroStore.java
+++ b/gora-core/src/main/java/org/apache/gora/avro/store/AvroStore.java
@@ -59,6 +59,11 @@ public class AvroStore<K, T extends PersistentBase>
 
   public static final Logger LOG = LoggerFactory.getLogger(AvroStore.class);
 
+  @Override
+  public boolean exists(K key) throws GoraException {
+    return get(key) != null;
+  }
+  
   /**
    * The type of the avro Encoder/Decoder.
    */

--- a/gora-core/src/main/java/org/apache/gora/memory/store/MemStore.java
+++ b/gora-core/src/main/java/org/apache/gora/memory/store/MemStore.java
@@ -195,8 +195,8 @@ public class MemStore<K, T extends PersistentBase> extends DataStoreBase<K, T> {
     }
     return getPersistent(obj, getFieldsToQuery(fields));
   }
-	
-	@SuppressWarnings("unchecked")
+
+  @SuppressWarnings("unchecked")
   @Override
   public boolean exists(K key) {
     return map.containsKey(key);

--- a/gora-core/src/main/java/org/apache/gora/memory/store/MemStore.java
+++ b/gora-core/src/main/java/org/apache/gora/memory/store/MemStore.java
@@ -195,6 +195,12 @@ public class MemStore<K, T extends PersistentBase> extends DataStoreBase<K, T> {
     }
     return getPersistent(obj, getFieldsToQuery(fields));
   }
+	
+	@SuppressWarnings("unchecked")
+  @Override
+  public boolean exists(K key) {
+    return map.containsKey(key);
+  }
 
   /**
    * Returns a clone with exactly the requested fields shallowly copied

--- a/gora-core/src/main/java/org/apache/gora/store/DataStore.java
+++ b/gora-core/src/main/java/org/apache/gora/store/DataStore.java
@@ -128,7 +128,16 @@ public interface DataStore<K, T extends Persistent> {
    */
   T newPersistent() throws GoraException;
 
-  /**
+	/**
+	 * Verify whether a key exists in the data store.
+	 *
+	 * @param key the key of the object
+	 * @return true if the key exists, false otherwise
+	 */
+	boolean exists(K key) throws GoraException;
+	
+	
+	/**
    * Returns the object corresponding to the given key fetching all the fields.
    * @param key the key of the object
    * @return the Object corresponding to the key or null if it cannot be found

--- a/gora-core/src/main/java/org/apache/gora/store/DataStore.java
+++ b/gora-core/src/main/java/org/apache/gora/store/DataStore.java
@@ -135,15 +135,15 @@ public interface DataStore<K, T extends Persistent> {
    */
   T newPersistent() throws GoraException;
 
-	/**
-	 * Verify whether a key exists in the data store.
-	 *
-	 * @param key the key of the object
-	 * @return true if the key exists, false otherwise
-	 */
-	boolean exists(K key) throws GoraException;
-	
-	
+  /**
+   * Verify whether a key exists in the data store.
+   *
+   * @param key the key of the object
+   * @return true if the key exists, false otherwise
+   */
+  boolean exists(K key) throws GoraException;
+
+
 	/**
    * Returns the object corresponding to the given key fetching all the fields.
    * @param key the key of the object.

--- a/gora-core/src/main/java/org/apache/gora/store/impl/DataStoreBase.java
+++ b/gora-core/src/main/java/org/apache/gora/store/impl/DataStoreBase.java
@@ -150,11 +150,6 @@ public abstract class DataStoreBase<K, T extends PersistentBase>
     return beanFactory;
   }
 
-	@Override
-	public boolean exists(K key) throws GoraException {
-		return get(key, new String[0]) != null;
-	}
-	
   @Override
   public T get(K key) throws GoraException {
     return get(key, getFieldsToQuery(null));

--- a/gora-core/src/main/java/org/apache/gora/store/impl/DataStoreBase.java
+++ b/gora-core/src/main/java/org/apache/gora/store/impl/DataStoreBase.java
@@ -150,6 +150,11 @@ public abstract class DataStoreBase<K, T extends PersistentBase>
     return beanFactory;
   }
 
+	@Override
+	public boolean exists(K key) throws GoraException {
+		return get(key, new String[0]) != null;
+	}
+	
   @Override
   public T get(K key) throws GoraException {
     return get(key, getFieldsToQuery(null));

--- a/gora-core/src/test/java/org/apache/gora/mock/store/MockDataStore.java
+++ b/gora-core/src/test/java/org/apache/gora/mock/store/MockDataStore.java
@@ -144,7 +144,12 @@ public class MockDataStore extends DataStoreBase<String, MockPersistent> {
   @Override
   public void setPersistentClass(Class<MockPersistent> persistentClass) {
   }
-  
+
+  @Override
+  public boolean exists(String key) throws GoraException {
+    return false;
+  }
+
   public static class MockResult<K, T extends PersistentBase> extends ResultBase<K, T> {
     
     public MockResult(DataStore<K, T> dataStore, Query<K, T> query) {

--- a/gora-core/src/test/java/org/apache/gora/store/DataStoreTestBase.java
+++ b/gora-core/src/test/java/org/apache/gora/store/DataStoreTestBase.java
@@ -214,18 +214,18 @@ public abstract class DataStoreTestBase {
     DataStoreTestUtil.testEmptyUpdateEmployee(employeeStore);
   }
 
-	@Test
-	public void testExists() throws Exception {
-		log.info("test method: testExists");
-		DataStoreTestUtil.testExistsEmployee(employeeStore);
-	}
-	
-	@Test
-	public void testBenchamarkExists() throws Exception {
-		log.info("test method: testBenchamarkExists");
-		DataStoreTestUtil.testBenchmarkGetExists(employeeStore);
-	}
-	
+  @Test
+  public void testExists() throws Exception {
+    log.info("test method: testExists");
+    DataStoreTestUtil.testExistsEmployee(employeeStore);
+  }
+
+  @Test
+  public void testBenchamarkExists() throws Exception {
+    log.info("test method: testBenchamarkExists");
+    DataStoreTestUtil.testBenchmarkGetExists(employeeStore);
+  }
+
   @Test
   public void testGet() throws Exception {
     log.info("test method: testGet");

--- a/gora-core/src/test/java/org/apache/gora/store/DataStoreTestBase.java
+++ b/gora-core/src/test/java/org/apache/gora/store/DataStoreTestBase.java
@@ -214,6 +214,18 @@ public abstract class DataStoreTestBase {
     DataStoreTestUtil.testEmptyUpdateEmployee(employeeStore);
   }
 
+	@Test
+	public void testExists() throws Exception {
+		log.info("test method: testExists");
+		DataStoreTestUtil.testExistsEmployee(employeeStore);
+	}
+	
+	@Test
+	public void testBenchamarkExists() throws Exception {
+		log.info("test method: testBenchamarkExists");
+		DataStoreTestUtil.testBenchmarkGetExists(employeeStore);
+	}
+	
   @Test
   public void testGet() throws Exception {
     log.info("test method: testGet");

--- a/gora-core/src/test/java/org/apache/gora/store/DataStoreTestUtil.java
+++ b/gora-core/src/test/java/org/apache/gora/store/DataStoreTestUtil.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -167,6 +168,49 @@ public class DataStoreTestUtil {
     dataStore.deleteSchema();
     assertFalse(dataStore.schemaExists());
   }
+	
+	public static void testExistsEmployee(DataStore<String, Employee> dataStore)
+			throws Exception {
+		dataStore.createSchema();
+		Employee employee = DataStoreTestUtil.createEmployee();
+		String ssn = employee.getSsn().toString();
+		dataStore.put(ssn, employee);
+		dataStore.flush();
+		assertTrue(dataStore.exists(ssn));
+		dataStore.delete(ssn);
+		dataStore.flush();
+		assertFalse(dataStore.exists(ssn));
+	}
+
+	public static void testBenchmarkGetExists(DataStore<String, Employee> dataStore)
+			throws Exception {
+		dataStore.createSchema();
+		List<String> listKey = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			listKey.add(UUID.randomUUID().toString());
+		}
+		for (String id : listKey) {
+			Employee employee = DataStoreTestUtil.createEmployee();
+			dataStore.put(id, employee);
+		}
+		dataStore.flush();
+		long start = System.currentTimeMillis();
+		for (String id : listKey) {
+			assertTrue(dataStore.exists(id));
+			assertFalse(dataStore.exists("mock:" + id));
+		}
+		long end = System.currentTimeMillis();
+		long total = end - start;
+		LOG.info("Time exists() : " + total);
+		start = System.currentTimeMillis();
+		for (String id : listKey) {
+			assertTrue(dataStore.get(id) != null);
+			assertFalse(dataStore.get("mock:" + id) != null);
+		}
+		end = System.currentTimeMillis();
+		total = end - start;
+		LOG.info("Time get() : " + total);
+	}
 
   public static void testGetEmployee(DataStore<String, Employee> dataStore)
     throws Exception {

--- a/gora-core/src/test/java/org/apache/gora/store/DataStoreTestUtil.java
+++ b/gora-core/src/test/java/org/apache/gora/store/DataStoreTestUtil.java
@@ -168,49 +168,49 @@ public class DataStoreTestUtil {
     dataStore.deleteSchema();
     assertFalse(dataStore.schemaExists());
   }
-	
-	public static void testExistsEmployee(DataStore<String, Employee> dataStore)
-			throws Exception {
-		dataStore.createSchema();
-		Employee employee = DataStoreTestUtil.createEmployee();
-		String ssn = employee.getSsn().toString();
-		dataStore.put(ssn, employee);
-		dataStore.flush();
-		assertTrue(dataStore.exists(ssn));
-		dataStore.delete(ssn);
-		dataStore.flush();
-		assertFalse(dataStore.exists(ssn));
-	}
 
-	public static void testBenchmarkGetExists(DataStore<String, Employee> dataStore)
-			throws Exception {
-		dataStore.createSchema();
-		List<String> listKey = new ArrayList<>();
-		for (int i = 0; i < 100; i++) {
-			listKey.add(UUID.randomUUID().toString());
-		}
-		for (String id : listKey) {
-			Employee employee = DataStoreTestUtil.createEmployee();
-			dataStore.put(id, employee);
-		}
-		dataStore.flush();
-		long start = System.currentTimeMillis();
-		for (String id : listKey) {
-			assertTrue(dataStore.exists(id));
-			assertFalse(dataStore.exists("mock:" + id));
-		}
-		long end = System.currentTimeMillis();
-		long total = end - start;
-		LOG.info("Time exists() : " + total);
-		start = System.currentTimeMillis();
-		for (String id : listKey) {
-			assertTrue(dataStore.get(id) != null);
-			assertFalse(dataStore.get("mock:" + id) != null);
-		}
-		end = System.currentTimeMillis();
-		total = end - start;
-		LOG.info("Time get() : " + total);
-	}
+  public static void testExistsEmployee(DataStore<String, Employee> dataStore)
+      throws Exception {
+    dataStore.createSchema();
+    Employee employee = DataStoreTestUtil.createEmployee();
+    String uuid = UUID.randomUUID().toString();
+    dataStore.put(uuid, employee);
+    dataStore.flush();
+    assertTrue(dataStore.exists(uuid));
+    dataStore.delete(uuid);
+    dataStore.flush();
+    assertFalse(dataStore.exists(uuid));
+  }
+
+  public static void testBenchmarkGetExists(DataStore<String, Employee> dataStore)
+      throws Exception {
+    dataStore.createSchema();
+    List<String> listKey = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      listKey.add(UUID.randomUUID().toString());
+    }
+    for (String id : listKey) {
+      Employee employee = DataStoreTestUtil.createEmployee();
+      dataStore.put(id, employee);
+    }
+    dataStore.flush();
+    long start = System.currentTimeMillis();
+    for (String id : listKey) {
+      assertTrue(dataStore.exists(id));
+      assertFalse(dataStore.exists("mock:" + id));
+    }
+    long end = System.currentTimeMillis();
+    long total = end - start;
+    LOG.info("Time exists() : {}", total);
+    start = System.currentTimeMillis();
+    for (String id : listKey) {
+      assertTrue(dataStore.get(id) != null);
+      assertFalse(dataStore.get("mock:" + id) != null);
+    }
+    end = System.currentTimeMillis();
+    total = end - start;
+    LOG.info("Time get() : {}", total);
+  }
 
   public static void testGetEmployee(DataStore<String, Employee> dataStore)
     throws Exception {

--- a/gora-couchdb/src/main/java/org/apache/gora/couchdb/store/CouchDBStore.java
+++ b/gora-couchdb/src/main/java/org/apache/gora/couchdb/store/CouchDBStore.java
@@ -235,8 +235,8 @@ public class CouchDBStore<K, T extends PersistentBase> extends DataStoreBase<K, 
       throw new GoraException(e);
     }
   }
-	
-	@Override
+
+  @Override
   public boolean exists(final K key) throws GoraException {
     try {
       return db.contains(key.toString());

--- a/gora-couchdb/src/main/java/org/apache/gora/couchdb/store/CouchDBStore.java
+++ b/gora-couchdb/src/main/java/org/apache/gora/couchdb/store/CouchDBStore.java
@@ -235,6 +235,15 @@ public class CouchDBStore<K, T extends PersistentBase> extends DataStoreBase<K, 
       throw new GoraException(e);
     }
   }
+	
+	@Override
+  public boolean exists(final K key) throws GoraException {
+    try {
+      return db.contains(key.toString());
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
   /**
    * Persist an object into the store.

--- a/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBAvroStore.java
+++ b/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBAvroStore.java
@@ -133,4 +133,9 @@ DataStoreBase<K, T> implements IDynamoDB<K, T> {
     // TODO Auto-generated method stub
     return false;
   }
+
+  @Override
+  public boolean exists(K key) throws GoraException {
+    return get(key) != null;
+  }
 }

--- a/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBNativeStore.java
+++ b/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBNativeStore.java
@@ -542,9 +542,9 @@ public class DynamoDBNativeStore<K, T extends Persistent> extends
     return rangeKey;
   }
 
-	@Override
-	public boolean exists(K key) throws GoraException {
-		return get (key)!=null;
-	}
+  @Override
+  public boolean exists(K key) throws GoraException {
+    return get(key) != null;
+  }
 
 }

--- a/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBNativeStore.java
+++ b/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBNativeStore.java
@@ -542,4 +542,9 @@ public class DynamoDBNativeStore<K, T extends Persistent> extends
     return rangeKey;
   }
 
+	@Override
+	public boolean exists(K key) throws GoraException {
+		return get (key)!=null;
+	}
+
 }

--- a/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBStore.java
+++ b/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBStore.java
@@ -584,8 +584,8 @@ public class DynamoDBStore<K, T extends Persistent> implements DataStore<K, T> {
     this.dynamoDBClient = dynamoDBClient;
   }
 
-	@Override
-	public boolean exists(K key) throws GoraException {
-		return dynamoDbStore.exists(key);
-	}
+  @Override
+  public boolean exists(K key) throws GoraException {
+    return dynamoDbStore.exists(key);
+  }
 }

--- a/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBStore.java
+++ b/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBStore.java
@@ -583,4 +583,9 @@ public class DynamoDBStore<K, T extends Persistent> implements DataStore<K, T> {
   public void setDynamoDBClient(AmazonDynamoDB dynamoDBClient) {
     this.dynamoDBClient = dynamoDBClient;
   }
+
+	@Override
+	public boolean exists(K key) throws GoraException {
+		return dynamoDbStore.exists(key);
+	}
 }

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -249,12 +249,12 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
       throw new GoraException(e);
     }
   }
-	
-	@Override
+
+  @Override
   public boolean exists(K key) throws GoraException {
-    try{
+    try {
       Get get = new Get(toBytes(key));
-			return table.exists(get);
+      return table.exists(get);
     } catch (GoraException e) {
       throw e;
     } catch (Exception e) {

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -249,6 +249,18 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
       throw new GoraException(e);
     }
   }
+	
+	@Override
+  public boolean exists(K key) throws GoraException {
+    try{
+      Get get = new Get(toBytes(key));
+			return table.exists(get);
+    } catch (GoraException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
   /**
    * {@inheritDoc} Serializes the Persistent data and saves in HBase. Topmost

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStore.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStore.java
@@ -176,6 +176,27 @@ public class IgniteStore<K, T extends PersistentBase> extends DataStoreBase<K, T
     }
   }
 
+	@Override
+  public boolean exists(K key) throws GoraException {
+    Object[] keyl = null;
+    if (igniteMapping.getPrimaryKey().size() == 1) {
+      keyl = new Object[]{key};
+    } else {
+      //Composite key pending
+    }
+    String selectQuery = IgniteSQLBuilder.createSelectQueryExists(igniteMapping);
+    try (PreparedStatement stmt = connection.prepareStatement(selectQuery)) {
+      IgniteSQLBuilder.fillSelectQuery(stmt, igniteMapping, keyl);
+      ResultSet rs = stmt.executeQuery();
+      rs.next();
+			int resp = rs.getInt(1);
+      rs.close();
+      return resp!=0;
+    } catch (SQLException ex) {
+      throw new GoraException(ex);
+    }
+  }
+
   @Override
   public T get(K key, String[] fields) throws GoraException {
     String[] avFields = getFieldsToQuery(fields);

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStore.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStore.java
@@ -176,7 +176,7 @@ public class IgniteStore<K, T extends PersistentBase> extends DataStoreBase<K, T
     }
   }
 
-	@Override
+  @Override
   public boolean exists(K key) throws GoraException {
     Object[] keyl = null;
     if (igniteMapping.getPrimaryKey().size() == 1) {
@@ -189,9 +189,9 @@ public class IgniteStore<K, T extends PersistentBase> extends DataStoreBase<K, T
       IgniteSQLBuilder.fillSelectQuery(stmt, igniteMapping, keyl);
       ResultSet rs = stmt.executeQuery();
       rs.next();
-			int resp = rs.getInt(1);
+      int resp = rs.getInt(1);
       rs.close();
-      return resp!=0;
+      return resp != 0;
     } catch (SQLException ex) {
       throw new GoraException(ex);
     }

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/utils/IgniteSQLBuilder.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/utils/IgniteSQLBuilder.java
@@ -181,7 +181,7 @@ public class IgniteSQLBuilder {
     }
   }
 
-	/**
+  /**
    * Returns a bare SQL statement for checking if a key exists
    *
    * @param mapping The ignite mapping definition of the data store
@@ -192,8 +192,8 @@ public class IgniteSQLBuilder {
     DbSchema schema = spec.addDefaultSchema();
     DbTable aTable = schema.addTable(mapping.getTableName());
     SelectQuery selectQuery = new SelectQuery();
-		selectQuery.addCustomColumns(FunctionCall.countAll());
-		selectQuery.addFromTable(aTable);
+    selectQuery.addCustomColumns(FunctionCall.countAll());
+    selectQuery.addFromTable(aTable);
     for (int i = 0; i < mapping.getPrimaryKey().size(); i++) {
       selectQuery.addCondition(new BinaryCondition(BinaryCondition.Op.EQUAL_TO,
           new DbColumn(aTable, mapping.getPrimaryKey().get(i).getName(), null),
@@ -201,7 +201,7 @@ public class IgniteSQLBuilder {
     }
     return selectQuery.validate().toString();
   }
-	
+
   /**
    * Returns a bare SQL statement for retrieving a record from the ignite data
    * store

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/utils/IgniteSQLBuilder.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/utils/IgniteSQLBuilder.java
@@ -22,6 +22,7 @@ import com.healthmarketscience.sqlbuilder.CreateTableQuery;
 import com.healthmarketscience.sqlbuilder.CustomSql;
 import com.healthmarketscience.sqlbuilder.DeleteQuery;
 import com.healthmarketscience.sqlbuilder.DropQuery;
+import com.healthmarketscience.sqlbuilder.FunctionCall;
 import com.healthmarketscience.sqlbuilder.InsertQuery;
 import com.healthmarketscience.sqlbuilder.SelectQuery;
 import com.healthmarketscience.sqlbuilder.SqlObject;
@@ -180,6 +181,27 @@ public class IgniteSQLBuilder {
     }
   }
 
+	/**
+   * Returns a bare SQL statement for checking if a key exists
+   *
+   * @param mapping The ignite mapping definition of the data store
+   * @return SQL select statement
+   */
+  public static String createSelectQueryExists(IgniteMapping mapping) {
+    DbSpec spec = new DbSpec();
+    DbSchema schema = spec.addDefaultSchema();
+    DbTable aTable = schema.addTable(mapping.getTableName());
+    SelectQuery selectQuery = new SelectQuery();
+		selectQuery.addCustomColumns(FunctionCall.countAll());
+		selectQuery.addFromTable(aTable);
+    for (int i = 0; i < mapping.getPrimaryKey().size(); i++) {
+      selectQuery.addCondition(new BinaryCondition(BinaryCondition.Op.EQUAL_TO,
+          new DbColumn(aTable, mapping.getPrimaryKey().get(i).getName(), null),
+          SqlObject.QUESTION_MARK));
+    }
+    return selectQuery.validate().toString();
+  }
+	
   /**
    * Returns a bare SQL statement for retrieving a record from the ignite data
    * store

--- a/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanStore.java
+++ b/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanStore.java
@@ -179,10 +179,10 @@ public class InfinispanStore<K, T extends PersistentBase> extends DataStoreBase<
       throw new GoraException(e);
     }
   }
-	
-	@Override
+
+  @Override
   public boolean exists(K key) throws GoraException {
-    LOG.debug("exists("+key+")");
+    LOG.debug("exists({})", key);
     try {
       return infinispanClient.containsKey(key);
     } catch (Exception e) {

--- a/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanStore.java
+++ b/gora-infinispan/src/main/java/org/apache/gora/infinispan/store/InfinispanStore.java
@@ -183,6 +183,16 @@ public class InfinispanStore<K, T extends PersistentBase> extends DataStoreBase<
       throw new GoraException(e);
     }
   }
+	
+	@Override
+  public boolean exists(K key) throws GoraException {
+    LOG.debug("exists("+key+")");
+    try {
+      return infinispanClient.containsKey(key);
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
   @Override
   public T get(K key, String[] fields) throws GoraException {

--- a/gora-jcache/src/main/java/org/apache/gora/jcache/store/JCacheStore.java
+++ b/gora-jcache/src/main/java/org/apache/gora/jcache/store/JCacheStore.java
@@ -334,6 +334,15 @@ public class JCacheStore<K, T extends PersistentBase> extends DataStoreBase<K, T
       throw new GoraException(e);
     }
   }
+	
+	@Override
+  public boolean exists(K key) throws GoraException {
+    try {
+			return cache.containsKey(key);
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
   @Override
   public T get(K key) throws GoraException {

--- a/gora-jcache/src/main/java/org/apache/gora/jcache/store/JCacheStore.java
+++ b/gora-jcache/src/main/java/org/apache/gora/jcache/store/JCacheStore.java
@@ -334,11 +334,11 @@ public class JCacheStore<K, T extends PersistentBase> extends DataStoreBase<K, T
       throw new GoraException(e);
     }
   }
-	
-	@Override
+
+  @Override
   public boolean exists(K key) throws GoraException {
     try {
-			return cache.containsKey(key);
+      return cache.containsKey(key);
     } catch (Exception e) {
       throw new GoraException(e);
     }

--- a/gora-lucene/src/main/java/org/apache/gora/lucene/store/LuceneStore.java
+++ b/gora-lucene/src/main/java/org/apache/gora/lucene/store/LuceneStore.java
@@ -272,6 +272,22 @@ public class LuceneStore<K, T extends PersistentBase>
     }
   }
 
+	@Override
+	public boolean exists(K key) throws GoraException{
+		boolean resp = false;
+		try {
+			final IndexSearcher s = searcherManager.acquire();
+			TermQuery q = new TermQuery(new Term(mapping.getPrimaryKey(), key.toString()));
+			if (s.count(q) > 0) {
+				resp = true;
+			}
+			searcherManager.release(s);
+		} catch (IOException e) {
+			LOG.error("Error in exists: {}", e);
+		}
+		return resp;
+	}
+	
   @Override
   public T get(K key, String[] fieldsToLoad) {
 

--- a/gora-lucene/src/main/java/org/apache/gora/lucene/store/LuceneStore.java
+++ b/gora-lucene/src/main/java/org/apache/gora/lucene/store/LuceneStore.java
@@ -272,22 +272,22 @@ public class LuceneStore<K, T extends PersistentBase>
     }
   }
 
-	@Override
-	public boolean exists(K key) throws GoraException{
-		boolean resp = false;
-		try {
-			final IndexSearcher s = searcherManager.acquire();
-			TermQuery q = new TermQuery(new Term(mapping.getPrimaryKey(), key.toString()));
-			if (s.count(q) > 0) {
-				resp = true;
-			}
-			searcherManager.release(s);
-		} catch (IOException e) {
-			LOG.error("Error in exists: {}", e);
-		}
-		return resp;
-	}
-	
+  @Override
+  public boolean exists(K key) throws GoraException {
+    boolean resp = false;
+    try {
+      final IndexSearcher s = searcherManager.acquire();
+      TermQuery q = new TermQuery(new Term(mapping.getPrimaryKey(), key.toString()));
+      if (s.count(q) > 0) {
+        resp = true;
+      }
+      searcherManager.release(s);
+    } catch (IOException e) {
+      LOG.error("Error in exists: {}", e);
+    }
+    return resp;
+  }
+
   @Override
   public T get(K key, String[] fieldsToLoad) {
 

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
@@ -380,16 +380,16 @@ DataStoreBase<K, T> {
       throw new GoraException(e);
     }
   }
-	
-	@Override
+
+  @Override
   public boolean exists(final K key) throws GoraException {
     try {
       // Prepare the MongoDB query
       BasicDBObject q = new BasicDBObject("_id", key);
-			BasicDBObject proj = new BasicDBObject();
+      BasicDBObject proj = new BasicDBObject();
       // Execute the query
       DBObject res = mongoClientColl.findOne(q, proj);
-      return res!=null;
+      return res != null;
     } catch (Exception e) {
       throw new GoraException(e);
     }

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
@@ -380,6 +380,20 @@ DataStoreBase<K, T> {
       throw new GoraException(e);
     }
   }
+	
+	@Override
+  public boolean exists(final K key) throws GoraException {
+    try {
+      // Prepare the MongoDB query
+      BasicDBObject q = new BasicDBObject("_id", key);
+			BasicDBObject proj = new BasicDBObject();
+      // Execute the query
+      DBObject res = mongoClientColl.findOne(q, proj);
+      return res!=null;
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
 
   /**
    * Persist an object into the store.

--- a/gora-orientdb/src/main/java/org/apache/gora/orientdb/store/OrientDBStore.java
+++ b/gora-orientdb/src/main/java/org/apache/gora/orientdb/store/OrientDBStore.java
@@ -955,4 +955,8 @@ public class OrientDBStore<K, T extends PersistentBase> extends DataStoreBase<K,
             .replace("\u00FB", "=");
   }
 
+  @Override
+  public boolean exists(K key) throws GoraException {
+    return get(key) != null;
+  }
 }

--- a/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
+++ b/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
@@ -543,7 +543,7 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
     return sb.toString();
   }
 
-	@Override
+  @Override
   public boolean exists(K key) throws GoraException {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set(CommonParams.QT, "/get");
@@ -552,12 +552,12 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
     try {
       QueryResponse rsp = server.query(params);
       Object o = rsp.getResponse().get("doc");
-      return o!=null;
+      return o != null;
     } catch (Exception e) {
       throw new GoraException(e);
     }
   }
-	
+
   @Override
   public T get(K key, String[] fields) throws GoraException {
     ModifiableSolrParams params = new ModifiableSolrParams();

--- a/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
+++ b/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
@@ -453,6 +453,21 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
     return sb.toString();
   }
 
+	@Override
+  public boolean exists(K key) throws GoraException {
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    params.set(CommonParams.QT, "/get");
+    params.set(CommonParams.FL, " ");
+    params.set("id", key.toString());
+    try {
+      QueryResponse rsp = server.query(params);
+      Object o = rsp.getResponse().get("doc");
+      return o!=null;
+    } catch (Exception e) {
+      throw new GoraException(e);
+    }
+  }
+	
   @Override
   public T get(K key, String[] fields) throws GoraException {
     ModifiableSolrParams params = new ModifiableSolrParams();


### PR DESCRIPTION
Adds a **exists(key)** method to the DataStores.

- Custom implementations for all backends.
- Two new tests for: operability and benchmark.

Your feedback would be appreciated :)