### PR TITLE
GORA-549: Remove PersistentBase extending java.io.Externalizable

### DIFF
--- a/gora-core/src/main/java/org/apache/gora/persistency/impl/PersistentBase.java
+++ b/gora-core/src/main/java/org/apache/gora/persistency/impl/PersistentBase.java
@@ -37,7 +37,7 @@ import org.apache.gora.persistency.Persistent;
 */
 @TypeInfo(PersistentTypeInfoFactory.class)
 public abstract class PersistentBase extends SpecificRecordBase implements
-    Persistent, java.io.Externalizable {
+        Persistent {
 
   /** Bytes used to represent weather or not a field is dirty. */
   private java.nio.ByteBuffer __g__dirty;


### PR DESCRIPTION
This is no longer required since SpecificRecordBase extends java.io.Externalizable with AVRO upgrade.