### PR TITLE
GORA-564: Remove deprecated method usages of HBase module after upgrading to 2

### DIFF
--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -626,7 +626,7 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
   private void addTimeRange(Get get, Query<K, T> query) throws IOException {
     if(query.getStartTime() > 0 || query.getEndTime() > 0) {
       if(query.getStartTime() == query.getEndTime()) {
-        get.setTimeStamp(query.getStartTime());
+        get.setTimestamp(query.getStartTime());
       } else {
         long startTime = query.getStartTime() > 0 ? query.getStartTime() : 0;
         long endTime = query.getEndTime() > 0 ? query.getEndTime() : Long.MAX_VALUE;

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStoreMetadataAnalyzer.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStoreMetadataAnalyzer.java
@@ -24,11 +24,13 @@ import java.util.stream.Collectors;
 
 import org.apache.gora.store.impl.DataStoreMetadataAnalyzer;
 import org.apache.gora.util.GoraException;
-import org.apache.hadoop.hbase.HTableDescriptor;
+
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+
 
 public class HBaseStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
 
@@ -66,7 +68,7 @@ public class HBaseStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
         try {
             Admin hbaseAdmin = this.hbaseConnection.getAdmin();
             TableName hbaseTableName =  TableName.valueOf(tableName);
-            HTableDescriptor tableDescriptor = hbaseAdmin.getTableDescriptor(hbaseTableName) ;
+            TableDescriptor tableDescriptor = hbaseAdmin.getDescriptor(hbaseTableName);
             HBaseTableMetadata tableMetadata = new HBaseTableMetadata() ;
             tableMetadata.getColumnFamilies().addAll(Arrays.stream(tableDescriptor.getColumnFamilies()).map(hcolumn -> hcolumn.getNameAsString()).collect(Collectors.toList())) ;
             hbaseAdmin.close();


### PR DESCRIPTION
Remove deprecated API calls from HbaseStore and HBaseStoreMetadataAnalyzer classes.