### PR TITLE
GORA-611: Fix intermittent test failures with HBase module

### DIFF
--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -98,6 +98,9 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
   private static final String SCANNER_CACHING_PROPERTIES_KEY = "scanner.caching" ;
   private static final int SCANNER_CACHING_PROPERTIES_DEFAULT = 0 ;
 
+  private static final String HBASE_CLIENT_AUTO_FLUSH_PROPERTIES_KEY = "hbase.client.autoflush.enabled";
+  private static final boolean HBASE_CLIENT_AUTO_FLUSH_PROPERTIES_DEFAULT = false;
+
   private static final int PUTS_AND_DELETES_PUT_TS_OFFSET = 1;
   private static final int PUTS_AND_DELETES_DELETE_TS_OFFSET = 2;
   
@@ -169,7 +172,9 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
     }
 
     try{
-      boolean autoflush = this.conf.getBoolean("hbase.client.autoflush.default", false);
+      boolean autoflush = Boolean.valueOf(DataStoreFactory.findProperty(this.properties, this,
+              HBASE_CLIENT_AUTO_FLUSH_PROPERTIES_KEY,
+              String.valueOf(HBASE_CLIENT_AUTO_FLUSH_PROPERTIES_DEFAULT)));
       table = new HBaseTableConnection(getConf(), getSchemaName(), autoflush);
     } catch (Exception e) {
       throw new GoraException(e);

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -210,7 +210,7 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
           admin.close();
         }
       } catch (IOException e) {
-        //Ignore
+        LOG.error("An error occurred whilst closing HBase Admin. ", e);
       }
     }
   }
@@ -235,7 +235,7 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
           admin.close();
         }
       } catch (IOException e) {
-        //Ignore
+        LOG.error("An error occurred whilst closing HBase Admin. ", e);
       }
     }
   }
@@ -254,7 +254,7 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
           admin.close();
         }
       } catch (IOException e) {
-        //Ignore
+        LOG.error("An error occurred whilst closing HBase Admin. ", e);
       }
     }
   }

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -68,7 +68,6 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseTableConnection.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseTableConnection.java
@@ -26,6 +26,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.BufferedMutator;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
@@ -36,6 +37,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Pair;
@@ -57,11 +59,10 @@ public class HBaseTableConnection {
   private final Connection connection;
   private final RegionLocator regionLocator;
   // BufferedMutator used for doing async flush i.e. autoflush = false
-  private final ThreadLocal<ConcurrentLinkedQueue<Mutation>> buffers;
-  private final ThreadLocal<Table> tables;
+  private final ConcurrentLinkedQueue<Mutation> buffer = new ConcurrentLinkedQueue<>();
+  private final ThreadLocal<Table> table;
 
   private final BlockingQueue<Table> tPool = new LinkedBlockingQueue<>();
-  private final BlockingQueue<ConcurrentLinkedQueue<Mutation>> bPool = new LinkedBlockingQueue<>();
   @SuppressWarnings("unused")
   private final boolean autoFlush;
   private final TableName tableName;
@@ -75,45 +76,30 @@ public class HBaseTableConnection {
    * @throws IOException
    */
   public HBaseTableConnection(Configuration conf, String tableName, boolean autoflush)
-      throws IOException {
+          throws IOException {
     this.conf = conf;
-
-    this.tables = new ThreadLocal<>();
-    this.buffers = new ThreadLocal<>();
+    this.table = new ThreadLocal<>();
     this.connection = ConnectionFactory.createConnection(conf);
     this.tableName = TableName.valueOf(tableName);
     this.regionLocator = this.connection.getRegionLocator(this.tableName);
-
     this.autoFlush = autoflush;
   }
 
   private Table getTable() throws IOException {
-    Table table = tables.get();
-    if (table == null) {
-      table = connection.getTable(tableName);
-      tPool.add(table); //keep track
-      tables.set(table);
+    Table tableRef = table.get();
+    if (tableRef == null) {
+      tableRef = connection.getTable(tableName);
+      tPool.add(tableRef); //keep track
+      table.set(tableRef);
     }
-    return table;
-  }
-
-  private ConcurrentLinkedQueue<Mutation> getBuffer() throws IOException {
-    ConcurrentLinkedQueue<Mutation> buffer = buffers.get();
-    if (buffer == null) {
-      buffer = new ConcurrentLinkedQueue<>();
-      bPool.add(buffer);
-      buffers.set(buffer);
-    }
-    return buffer;
+    return tableRef;
   }
 
   public void flushCommits() throws IOException {
     BufferedMutator bufMutator = connection.getBufferedMutator(this.tableName);
-    for (ConcurrentLinkedQueue<Mutation> buffer : bPool) {
-      while (!buffer.isEmpty()) {
-        Mutation m = buffer.poll();
-        bufMutator.mutate(m);
-      }
+    while (!buffer.isEmpty()) {
+      Mutation m = buffer.poll();
+      bufMutator.mutate(m);
     }
     bufMutator.flush();
     bufMutator.close();
@@ -129,6 +115,10 @@ public class HBaseTableConnection {
     for (Table table : tPool) {
       table.close();
     }
+
+    if (!connection.isClosed()) {
+      connection.close();
+    }
   }
 
   public Configuration getConfiguration() {
@@ -137,13 +127,16 @@ public class HBaseTableConnection {
 
   /**
    * getStartEndKeys provided by {@link HRegionLocation}.
+   *
    * @see RegionLocator#getStartEndKeys()
    */
   public Pair<byte[][], byte[][]> getStartEndKeys() throws IOException {
     return regionLocator.getStartEndKeys();
   }
+
   /**
    * getRegionLocation provided by {@link HRegionLocation}
+   *
    * @see RegionLocator#getRegionLocation(byte[])
    */
   public HRegionLocation getRegionLocation(final byte[] bs) throws IOException {
@@ -170,23 +163,43 @@ public class HBaseTableConnection {
     return getTable().getScanner(scan);
   }
 
+  public void mutateRow(RowMutations m) throws IOException {
+    getTable().mutateRow(m);
+  }
+
   public void put(Put put) throws IOException {
-    getBuffer().add(put);
+    buffer.add(put);
+    if (autoFlush) {
+      flushCommits();
+    }
   }
 
   public void put(List<Put> puts) throws IOException {
-    getBuffer().addAll(puts);
+    buffer.addAll(puts);
+    if (autoFlush) {
+      flushCommits();
+    }
   }
 
   public void delete(Delete delete) throws IOException {
-    getBuffer().add(delete);
+    buffer.add(delete);
+    if (autoFlush) {
+      flushCommits();
+    }
   }
 
   public void delete(List<Delete> deletes) throws IOException {
-    getBuffer().addAll(deletes);
+    buffer.addAll(deletes);
+    if (autoFlush) {
+      flushCommits();
+    }
   }
 
   public TableName getName() {
     return tableName;
+  }
+
+  public Admin getAdmin() throws IOException {
+    return connection.getAdmin();
   }
 }

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseTableConnection.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseTableConnection.java
@@ -163,7 +163,7 @@ public class HBaseTableConnection {
     return getTable().getScanner(scan);
   }
 
-  public void updateRow(byte[] keyRaw, Put put, Delete delete) throws IOException {
+  public void updateRow(byte[] keyRaw, Mutation put, Mutation delete) throws IOException {
     if (autoFlush) {
       Table tableInstance = getTable();
       if (put.size() > 0) {
@@ -173,11 +173,11 @@ public class HBaseTableConnection {
           update.add(put);
           tableInstance.mutateRow(update);
         } else {
-          tableInstance.put(put);
+          tableInstance.put((Put) put);
         }
       } else {
         if (delete.size() > 0) {
-          tableInstance.delete(delete);
+          tableInstance.delete((Delete) delete);
         }
       }
     } else {

--- a/gora-hbase/src/test/conf/gora.properties
+++ b/gora-hbase/src/test/conf/gora.properties
@@ -18,4 +18,4 @@
 
 #Caching option for HBaseStore
 gora.hbasestore.scanner.caching=1000
-hbase.client.autoflush.default=true
+gora.hbasestore.hbase.client.autoflush.enabled=true

--- a/gora-hbase/src/test/conf/gora.properties
+++ b/gora-hbase/src/test/conf/gora.properties
@@ -18,3 +18,4 @@
 
 #Caching option for HBaseStore
 gora.hbasestore.scanner.caching=1000
+hbase.client.autoflush.default=true

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/mapreduce/TestHBaseStoreCountQuery.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/mapreduce/TestHBaseStoreCountQuery.java
@@ -45,7 +45,8 @@ public class TestHBaseStoreCountQuery {
 
   @After
   public void tearDown() throws Exception {
-    webPageStore.close();
+    // This webPageStore datastore is closed from testCountQuery()
+    // webPageStore.close();
   }
   
   @Test

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStore.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStore.java
@@ -55,16 +55,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-
 /**
  * Test case for HBaseStore.
  */
@@ -133,6 +123,7 @@ public class TestHBaseStore extends DataStoreTestBase {
     // to retrieve the union correctly
     
     // Test writing+reading a null value. FIELD in HBASE MUST become DELETED
+    webPageStore = testDriver.createDataStore(String.class, WebPage.class);
     WebPage page = webPageStore.get("com.example/http") ;
     page.setContent(null) ;
     webPageStore.put("com.example/http", page) ;

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/util/TestHBaseByteInterface.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/util/TestHBaseByteInterface.java
@@ -35,11 +35,13 @@ import org.apache.gora.examples.generated.Metadata;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Ignore
 public class TestHBaseByteInterface {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestHBaseByteInterface.class);

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/util/TestHBaseByteInterface.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/util/TestHBaseByteInterface.java
@@ -35,13 +35,11 @@ import org.apache.gora.examples.generated.Metadata;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Ignore
 public class TestHBaseByteInterface {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestHBaseByteInterface.class);


### PR DESCRIPTION
Fix various issues such as resource closing, auto flush etc. https://issues.apache.org/jira/browse/HBASE-2256 -  main concern here is sometime back we addressed this issue, by differentiating timestamp values for HBase put/delete in put (K key, V value). However it seems, sometimes this fails intermittently. I have used atomic row update  - RowMutations instead of buffered mutator and the tests seems to passing solidly. 