### PR TITLE
GORA-271 Make consistent across datastores the way of getting the mapping filename

### DIFF
--- a/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBStore.java
+++ b/gora-dynamodb/src/main/java/org/apache/gora/dynamodb/store/DynamoDBStore.java
@@ -41,6 +41,7 @@ import org.apache.gora.query.PartitionQuery;
 import org.apache.gora.query.Query;
 import org.apache.gora.query.Result;
 import org.apache.gora.store.DataStore;
+import org.apache.gora.store.DataStoreFactory;
 import org.apache.gora.util.GoraException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -226,7 +227,9 @@ public class DynamoDBStore<K, T extends Persistent> implements DataStore<K, T> {
     setDynamoDBClient(DynamoDBUtils.getClient(
         properties.getProperty(CLI_TYP_PROP), creds));
     getDynamoDBClient().setEndpoint(properties.getProperty(ENDPOINT_PROP));
-    setDynamoDbMapping(readMapping());
+    String mappingFile = DataStoreFactory.getMappingFile(properties, this,
+            MAPPING_FILE);
+    setDynamoDbMapping(readMapping(mappingFile));
     setConsistency(properties.getProperty(CONSISTENCY_READS));
   }
 
@@ -311,14 +314,14 @@ public class DynamoDBStore<K, T extends Persistent> implements DataStore<K, T> {
    * @throws IOException
    */
   @SuppressWarnings("unchecked")
-  private DynamoDBMapping readMapping() throws IOException {
+  private DynamoDBMapping readMapping(String filename) throws IOException {
 
     DynamoDBMappingBuilder mappingBuilder = new DynamoDBMappingBuilder();
 
     try {
       SAXBuilder builder = new SAXBuilder();
       Document doc = builder.build(getClass().getClassLoader()
-          .getResourceAsStream(MAPPING_FILE));
+          .getResourceAsStream(filename));
       if (doc == null || doc.getRootElement() == null)
         throw new GoraException("Unable to load " + MAPPING_FILE
             + ". Please check its existance!");

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -22,10 +22,8 @@ import static org.apache.gora.hbase.util.HBaseByteInterface.toBytes;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URLClassLoader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,7 +41,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.util.Utf8;
-import org.apache.commons.io.IOUtils;
 import org.apache.gora.hbase.query.HBaseGetResult;
 import org.apache.gora.hbase.query.HBaseQuery;
 import org.apache.gora.hbase.query.HBaseScannerResult;


### PR DESCRIPTION
This PR will change the `HBaseStore` and `DynamoDBStore` to use `DataStoreFactory.getMappingFile()` method, when retrieving the filename for the mapping file from the properties file.

`CassandraStore` is already fixed.