### PR TITLE
GORA-396 Correct GoraCompiler formatting for embedded Tombstone class

### DIFF
--- a/gora-cassandra/src/examples/java/org/apache/gora/cassandra/example/generated/AvroSerialization/CassandraKey.java
+++ b/gora-cassandra/src/examples/java/org/apache/gora/cassandra/example/generated/AvroSerialization/CassandraKey.java
@@ -115,6 +115,7 @@ public class CassandraKey extends org.apache.gora.persistency.impl.PersistentBas
   
   /**
    * Checks the dirty status of the 'url' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isUrlDirty() {
     return isDirty(0);
@@ -138,6 +139,7 @@ public class CassandraKey extends org.apache.gora.persistency.impl.PersistentBas
   
   /**
    * Checks the dirty status of the 'timestamp' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isTimestampDirty() {
     return isDirty(1);
@@ -281,7 +283,7 @@ public class CassandraKey extends org.apache.gora.persistency.impl.PersistentBas
   }
   
   public CassandraKey.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public CassandraKey newInstance(){
@@ -292,53 +294,55 @@ public class CassandraKey extends org.apache.gora.persistency.impl.PersistentBas
   
   public static final class Tombstone extends CassandraKey implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'url' field.
-		   */
-	  public java.lang.CharSequence getUrl() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'url' field.
-		   * @param value the value to set.
-	   */
-	  public void setUrl(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'url' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isUrlDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'timestamp' field.
-		   */
-	  public java.lang.Long getTimestamp() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'timestamp' field.
-		   * @param value the value to set.
-	   */
-	  public void setTimestamp(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'timestamp' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isTimestampDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'url' field.
+         */
+    public java.lang.CharSequence getUrl() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'url' field.
+         * @param value the value to set.
+     */
+    public void setUrl(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'url' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isUrlDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'timestamp' field.
+         */
+    public java.lang.Long getTimestamp() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'timestamp' field.
+         * @param value the value to set.
+     */
+    public void setTimestamp(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'timestamp' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isTimestampDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-cassandra/src/examples/java/org/apache/gora/cassandra/example/generated/AvroSerialization/CassandraRecord.java
+++ b/gora-cassandra/src/examples/java/org/apache/gora/cassandra/example/generated/AvroSerialization/CassandraRecord.java
@@ -170,6 +170,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'dataString' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isDataStringDirty() {
     return isDirty(0);
@@ -193,6 +194,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'dataInt' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isDataIntDirty() {
     return isDirty(1);
@@ -216,6 +218,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'dataLong' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isDataLongDirty() {
     return isDirty(2);
@@ -239,6 +242,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'dataDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isDataDoubleDirty() {
     return isDirty(3);
@@ -262,6 +266,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'dataBytes' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isDataBytesDirty() {
     return isDirty(4);
@@ -285,6 +290,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'arrayInt' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isArrayIntDirty() {
     return isDirty(5);
@@ -308,6 +314,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'arrayString' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isArrayStringDirty() {
     return isDirty(6);
@@ -331,6 +338,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'arrayLong' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isArrayLongDirty() {
     return isDirty(7);
@@ -354,6 +362,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'arrayDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isArrayDoubleDirty() {
     return isDirty(8);
@@ -377,6 +386,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'mapInt' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isMapIntDirty() {
     return isDirty(9);
@@ -400,6 +410,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'mapString' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isMapStringDirty() {
     return isDirty(10);
@@ -423,6 +434,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'mapLong' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isMapLongDirty() {
     return isDirty(11);
@@ -446,6 +458,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   /**
    * Checks the dirty status of the 'mapDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
+   * @param value the value to set.
    */
   public boolean isMapDoubleDirty() {
     return isDirty(12);
@@ -930,7 +943,7 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   }
   
   public CassandraRecord.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public CassandraRecord newInstance(){
@@ -941,295 +954,308 @@ public class CassandraRecord extends org.apache.gora.persistency.impl.Persistent
   
   public static final class Tombstone extends CassandraRecord implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'dataString' field.
-		   */
-	  public java.lang.CharSequence getDataString() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'dataString' field.
-		   * @param value the value to set.
-	   */
-	  public void setDataString(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'dataString' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isDataStringDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'dataInt' field.
-		   */
-	  public java.lang.Integer getDataInt() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'dataInt' field.
-		   * @param value the value to set.
-	   */
-	  public void setDataInt(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'dataInt' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isDataIntDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'dataLong' field.
-		   */
-	  public java.lang.Long getDataLong() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'dataLong' field.
-		   * @param value the value to set.
-	   */
-	  public void setDataLong(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'dataLong' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isDataLongDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'dataDouble' field.
-		   */
-	  public java.lang.Double getDataDouble() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'dataDouble' field.
-		   * @param value the value to set.
-	   */
-	  public void setDataDouble(java.lang.Double value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'dataDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isDataDoubleDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'dataBytes' field.
-		   */
-	  public java.nio.ByteBuffer getDataBytes() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'dataBytes' field.
-		   * @param value the value to set.
-	   */
-	  public void setDataBytes(java.nio.ByteBuffer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'dataBytes' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isDataBytesDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'arrayInt' field.
-		   */
-	  public java.util.List<java.lang.Integer> getArrayInt() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'arrayInt' field.
-		   * @param value the value to set.
-	   */
-	  public void setArrayInt(java.util.List<java.lang.Integer> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'arrayInt' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isArrayIntDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'arrayString' field.
-		   */
-	  public java.util.List<java.lang.CharSequence> getArrayString() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'arrayString' field.
-		   * @param value the value to set.
-	   */
-	  public void setArrayString(java.util.List<java.lang.CharSequence> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'arrayString' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isArrayStringDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'arrayLong' field.
-		   */
-	  public java.util.List<java.lang.Long> getArrayLong() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'arrayLong' field.
-		   * @param value the value to set.
-	   */
-	  public void setArrayLong(java.util.List<java.lang.Long> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'arrayLong' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isArrayLongDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'arrayDouble' field.
-		   */
-	  public java.util.List<java.lang.Double> getArrayDouble() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'arrayDouble' field.
-		   * @param value the value to set.
-	   */
-	  public void setArrayDouble(java.util.List<java.lang.Double> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'arrayDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isArrayDoubleDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'mapInt' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.Integer> getMapInt() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'mapInt' field.
-		   * @param value the value to set.
-	   */
-	  public void setMapInt(java.util.Map<java.lang.CharSequence,java.lang.Integer> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'mapInt' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isMapIntDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'mapString' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getMapString() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'mapString' field.
-		   * @param value the value to set.
-	   */
-	  public void setMapString(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'mapString' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isMapStringDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'mapLong' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.Long> getMapLong() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'mapLong' field.
-		   * @param value the value to set.
-	   */
-	  public void setMapLong(java.util.Map<java.lang.CharSequence,java.lang.Long> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'mapLong' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isMapLongDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'mapDouble' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.Double> getMapDouble() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'mapDouble' field.
-		   * @param value the value to set.
-	   */
-	  public void setMapDouble(java.util.Map<java.lang.CharSequence,java.lang.Double> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'mapDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
-	   */
-	  public boolean isMapDoubleDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'dataString' field.
+         */
+    public java.lang.CharSequence getDataString() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'dataString' field.
+         * @param value the value to set.
+     */
+    public void setDataString(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'dataString' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isDataStringDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'dataInt' field.
+         */
+    public java.lang.Integer getDataInt() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'dataInt' field.
+         * @param value the value to set.
+     */
+    public void setDataInt(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'dataInt' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isDataIntDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'dataLong' field.
+         */
+    public java.lang.Long getDataLong() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'dataLong' field.
+         * @param value the value to set.
+     */
+    public void setDataLong(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'dataLong' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isDataLongDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'dataDouble' field.
+         */
+    public java.lang.Double getDataDouble() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'dataDouble' field.
+         * @param value the value to set.
+     */
+    public void setDataDouble(java.lang.Double value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'dataDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isDataDoubleDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'dataBytes' field.
+         */
+    public java.nio.ByteBuffer getDataBytes() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'dataBytes' field.
+         * @param value the value to set.
+     */
+    public void setDataBytes(java.nio.ByteBuffer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'dataBytes' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isDataBytesDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'arrayInt' field.
+         */
+    public java.util.List<java.lang.Integer> getArrayInt() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'arrayInt' field.
+         * @param value the value to set.
+     */
+    public void setArrayInt(java.util.List<java.lang.Integer> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'arrayInt' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isArrayIntDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'arrayString' field.
+         */
+    public java.util.List<java.lang.CharSequence> getArrayString() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'arrayString' field.
+         * @param value the value to set.
+     */
+    public void setArrayString(java.util.List<java.lang.CharSequence> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'arrayString' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isArrayStringDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'arrayLong' field.
+         */
+    public java.util.List<java.lang.Long> getArrayLong() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'arrayLong' field.
+         * @param value the value to set.
+     */
+    public void setArrayLong(java.util.List<java.lang.Long> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'arrayLong' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isArrayLongDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'arrayDouble' field.
+         */
+    public java.util.List<java.lang.Double> getArrayDouble() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'arrayDouble' field.
+         * @param value the value to set.
+     */
+    public void setArrayDouble(java.util.List<java.lang.Double> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'arrayDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isArrayDoubleDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'mapInt' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.Integer> getMapInt() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'mapInt' field.
+         * @param value the value to set.
+     */
+    public void setMapInt(java.util.Map<java.lang.CharSequence,java.lang.Integer> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'mapInt' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isMapIntDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'mapString' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getMapString() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'mapString' field.
+         * @param value the value to set.
+     */
+    public void setMapString(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'mapString' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isMapStringDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'mapLong' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.Long> getMapLong() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'mapLong' field.
+         * @param value the value to set.
+     */
+    public void setMapLong(java.util.Map<java.lang.CharSequence,java.lang.Long> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'mapLong' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isMapLongDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'mapDouble' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.Double> getMapDouble() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'mapDouble' field.
+         * @param value the value to set.
+     */
+    public void setMapDouble(java.util.Map<java.lang.CharSequence,java.lang.Double> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'mapDouble' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isMapDoubleDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-compiler/src/main/velocity/org/apache/gora/compiler/templates/record.vm
+++ b/gora-compiler/src/main/velocity/org/apache/gora/compiler/templates/record.vm
@@ -313,7 +313,7 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   }
   
   public ${this.mangle($schema.getName())}.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public ${this.mangle($schema.getName())} newInstance(){
@@ -324,38 +324,44 @@ public class ${this.mangle($schema.getName())}#if ($schema.isError()) extends or
   
   public static final class Tombstone extends ${this.mangle($schema.getName())} implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  #foreach ($field in $schema.getFields())
-	#if ($this.isNotHiddenField($field.name()))
-	  /**
-	   * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
-	#if ($field.doc())   * $field.doc()#end
-	   */
-	  public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
-	#if ($field.doc())   * $field.doc()#end
-	   * @param value the value to set.
-	   */
-	  public void ${this.generateSetMethod($schema, $field)}(${this.javaType($field.schema())} value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the '${this.mangle($field.name(), $schema.isError())}' field. A field is dirty if it represents a change that has not yet been written to the database.
-	#if ($field.doc())   * $field.doc()#end
-	   * @param value the value to set.
-	   */
-	  public boolean ${this.generateDirtyMethod($schema, $field)}() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-	#end
-	#end
+#foreach ($field in $schema.getFields())
+  #if ($this.isNotHiddenField($field.name()))
+    /**
+     * Gets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
+    #if ($field.doc())   
+     * $field.doc()
+    #end
+     */
+    public ${this.javaType($field.schema())} ${this.generateGetMethod($schema, $field)}() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the '${this.mangle($field.name(), $schema.isError())}' field.
+    #if ($field.doc())   
+     * $field.doc()
+    #end
+     * @param value the value to set.
+     */
+    public void ${this.generateSetMethod($schema, $field)}(${this.javaType($field.schema())} value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the '${this.mangle($field.name(), $schema.isError())}' field. A field is dirty if it represents a change that has not yet been written to the database.
+    #if ($field.doc())   
+     * $field.doc()
+    #end
+     * @param value the value to set.
+     */
+    public boolean ${this.generateDirtyMethod($schema, $field)}() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+  #end
+#end
   
   }
 

--- a/gora-core/src/examples/java/org/apache/gora/examples/generated/Employee.java
+++ b/gora-core/src/examples/java/org/apache/gora/examples/generated/Employee.java
@@ -521,7 +521,7 @@ public class Employee extends org.apache.gora.persistency.impl.PersistentBase im
   }
   
   public Employee.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public Employee newInstance(){
@@ -532,147 +532,147 @@ public class Employee extends org.apache.gora.persistency.impl.PersistentBase im
   
   public static final class Tombstone extends Employee implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'name' field.
-		   */
-	  public java.lang.CharSequence getName() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'name' field.
-		   * @param value the value to set.
-	   */
-	  public void setName(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'name' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isNameDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'dateOfBirth' field.
-		   */
-	  public java.lang.Long getDateOfBirth() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'dateOfBirth' field.
-		   * @param value the value to set.
-	   */
-	  public void setDateOfBirth(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'dateOfBirth' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isDateOfBirthDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'ssn' field.
-		   */
-	  public java.lang.CharSequence getSsn() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'ssn' field.
-		   * @param value the value to set.
-	   */
-	  public void setSsn(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'ssn' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isSsnDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'salary' field.
-		   */
-	  public java.lang.Integer getSalary() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'salary' field.
-		   * @param value the value to set.
-	   */
-	  public void setSalary(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'salary' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isSalaryDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'boss' field.
-		   */
-	  public java.lang.Object getBoss() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'boss' field.
-		   * @param value the value to set.
-	   */
-	  public void setBoss(java.lang.Object value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'boss' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isBossDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'webpage' field.
-		   */
-	  public org.apache.gora.examples.generated.WebPage getWebpage() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'webpage' field.
-		   * @param value the value to set.
-	   */
-	  public void setWebpage(org.apache.gora.examples.generated.WebPage value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'webpage' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isWebpageDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'name' field.
+         */
+    public java.lang.CharSequence getName() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'name' field.
+         * @param value the value to set.
+     */
+    public void setName(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'name' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isNameDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'dateOfBirth' field.
+         */
+    public java.lang.Long getDateOfBirth() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'dateOfBirth' field.
+         * @param value the value to set.
+     */
+    public void setDateOfBirth(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'dateOfBirth' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isDateOfBirthDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'ssn' field.
+         */
+    public java.lang.CharSequence getSsn() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'ssn' field.
+         * @param value the value to set.
+     */
+    public void setSsn(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'ssn' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isSsnDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'salary' field.
+         */
+    public java.lang.Integer getSalary() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'salary' field.
+         * @param value the value to set.
+     */
+    public void setSalary(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'salary' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isSalaryDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'boss' field.
+         */
+    public java.lang.Object getBoss() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'boss' field.
+         * @param value the value to set.
+     */
+    public void setBoss(java.lang.Object value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'boss' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isBossDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'webpage' field.
+         */
+    public org.apache.gora.examples.generated.WebPage getWebpage() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'webpage' field.
+         * @param value the value to set.
+     */
+    public void setWebpage(org.apache.gora.examples.generated.WebPage value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'webpage' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isWebpageDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-core/src/examples/java/org/apache/gora/examples/generated/EmployeeInt.java
+++ b/gora-core/src/examples/java/org/apache/gora/examples/generated/EmployeeInt.java
@@ -222,7 +222,7 @@ public class EmployeeInt extends org.apache.gora.persistency.impl.PersistentBase
   }
   
   public EmployeeInt.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public EmployeeInt newInstance(){
@@ -233,32 +233,32 @@ public class EmployeeInt extends org.apache.gora.persistency.impl.PersistentBase
   
   public static final class Tombstone extends EmployeeInt implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'ssn' field.
-		   */
-	  public java.lang.Integer getSsn() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'ssn' field.
-		   * @param value the value to set.
-	   */
-	  public void setSsn(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'ssn' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isSsnDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'ssn' field.
+         */
+    public java.lang.Integer getSsn() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'ssn' field.
+         * @param value the value to set.
+     */
+    public void setSsn(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'ssn' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isSsnDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-core/src/examples/java/org/apache/gora/examples/generated/ImmutableFields.java
+++ b/gora-core/src/examples/java/org/apache/gora/examples/generated/ImmutableFields.java
@@ -283,7 +283,7 @@ public class ImmutableFields extends org.apache.gora.persistency.impl.Persistent
   }
   
   public ImmutableFields.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public ImmutableFields newInstance(){
@@ -294,55 +294,55 @@ public class ImmutableFields extends org.apache.gora.persistency.impl.Persistent
   
   public static final class Tombstone extends ImmutableFields implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'v1' field.
-		   */
-	  public java.lang.Integer getV1() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'v1' field.
-		   * @param value the value to set.
-	   */
-	  public void setV1(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'v1' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isV1Dirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'v2' field.
-		   */
-	  public org.apache.gora.examples.generated.V2 getV2() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'v2' field.
-		   * @param value the value to set.
-	   */
-	  public void setV2(org.apache.gora.examples.generated.V2 value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'v2' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isV2Dirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'v1' field.
+         */
+    public java.lang.Integer getV1() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'v1' field.
+         * @param value the value to set.
+     */
+    public void setV1(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'v1' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isV1Dirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'v2' field.
+         */
+    public org.apache.gora.examples.generated.V2 getV2() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'v2' field.
+         * @param value the value to set.
+     */
+    public void setV2(org.apache.gora.examples.generated.V2 value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'v2' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isV2Dirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-core/src/examples/java/org/apache/gora/examples/generated/Metadata.java
+++ b/gora-core/src/examples/java/org/apache/gora/examples/generated/Metadata.java
@@ -270,7 +270,7 @@ public class Metadata extends org.apache.gora.persistency.impl.PersistentBase im
   }
   
   public Metadata.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public Metadata newInstance(){
@@ -281,55 +281,55 @@ public class Metadata extends org.apache.gora.persistency.impl.PersistentBase im
   
   public static final class Tombstone extends Metadata implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'version' field.
-		   */
-	  public java.lang.Integer getVersion() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'version' field.
-		   * @param value the value to set.
-	   */
-	  public void setVersion(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'version' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isVersionDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'data' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getData() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'data' field.
-		   * @param value the value to set.
-	   */
-	  public void setData(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'data' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isDataDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'version' field.
+         */
+    public java.lang.Integer getVersion() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'version' field.
+         * @param value the value to set.
+     */
+    public void setVersion(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'version' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isVersionDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'data' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getData() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'data' field.
+         * @param value the value to set.
+     */
+    public void setData(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'data' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isDataDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-core/src/examples/java/org/apache/gora/examples/generated/TokenDatum.java
+++ b/gora-core/src/examples/java/org/apache/gora/examples/generated/TokenDatum.java
@@ -222,7 +222,7 @@ public class TokenDatum extends org.apache.gora.persistency.impl.PersistentBase 
   }
   
   public TokenDatum.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public TokenDatum newInstance(){
@@ -233,32 +233,32 @@ public class TokenDatum extends org.apache.gora.persistency.impl.PersistentBase 
   
   public static final class Tombstone extends TokenDatum implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'count' field.
-		   */
-	  public java.lang.Integer getCount() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'count' field.
-		   * @param value the value to set.
-	   */
-	  public void setCount(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'count' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isCountDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'count' field.
+         */
+    public java.lang.Integer getCount() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'count' field.
+         * @param value the value to set.
+     */
+    public void setCount(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'count' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isCountDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-core/src/examples/java/org/apache/gora/examples/generated/V2.java
+++ b/gora-core/src/examples/java/org/apache/gora/examples/generated/V2.java
@@ -210,7 +210,7 @@ public class V2 extends org.apache.gora.persistency.impl.PersistentBase implemen
   }
   
   public V2.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public V2 newInstance(){
@@ -221,32 +221,32 @@ public class V2 extends org.apache.gora.persistency.impl.PersistentBase implemen
   
   public static final class Tombstone extends V2 implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'v3' field.
-		   */
-	  public java.lang.Integer getV3() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'v3' field.
-		   * @param value the value to set.
-	   */
-	  public void setV3(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'v3' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isV3Dirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'v3' field.
+         */
+    public java.lang.Integer getV3() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'v3' field.
+         * @param value the value to set.
+     */
+    public void setV3(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'v3' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isV3Dirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-core/src/examples/java/org/apache/gora/examples/generated/WebPage.java
+++ b/gora-core/src/examples/java/org/apache/gora/examples/generated/WebPage.java
@@ -643,7 +643,7 @@ public class WebPage extends org.apache.gora.persistency.impl.PersistentBase imp
   }
   
   public WebPage.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public WebPage newInstance(){
@@ -654,193 +654,193 @@ public class WebPage extends org.apache.gora.persistency.impl.PersistentBase imp
   
   public static final class Tombstone extends WebPage implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'url' field.
-		   */
-	  public java.lang.CharSequence getUrl() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'url' field.
-		   * @param value the value to set.
-	   */
-	  public void setUrl(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'url' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isUrlDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'content' field.
-		   */
-	  public java.nio.ByteBuffer getContent() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'content' field.
-		   * @param value the value to set.
-	   */
-	  public void setContent(java.nio.ByteBuffer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'content' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isContentDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'parsedContent' field.
-		   */
-	  public java.util.List<java.lang.CharSequence> getParsedContent() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'parsedContent' field.
-		   * @param value the value to set.
-	   */
-	  public void setParsedContent(java.util.List<java.lang.CharSequence> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'parsedContent' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isParsedContentDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'outlinks' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getOutlinks() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'outlinks' field.
-		   * @param value the value to set.
-	   */
-	  public void setOutlinks(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'outlinks' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isOutlinksDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'headers' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getHeaders() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'headers' field.
-		   * @param value the value to set.
-	   */
-	  public void setHeaders(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'headers' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isHeadersDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'metadata' field.
-		   */
-	  public org.apache.gora.examples.generated.Metadata getMetadata() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'metadata' field.
-		   * @param value the value to set.
-	   */
-	  public void setMetadata(org.apache.gora.examples.generated.Metadata value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'metadata' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isMetadataDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'byteData' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.nio.ByteBuffer> getByteData() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'byteData' field.
-		   * @param value the value to set.
-	   */
-	  public void setByteData(java.util.Map<java.lang.CharSequence,java.nio.ByteBuffer> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'byteData' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isByteDataDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'stringData' field.
-		   */
-	  public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getStringData() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'stringData' field.
-		   * @param value the value to set.
-	   */
-	  public void setStringData(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'stringData' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isStringDataDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'url' field.
+         */
+    public java.lang.CharSequence getUrl() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'url' field.
+         * @param value the value to set.
+     */
+    public void setUrl(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'url' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isUrlDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'content' field.
+         */
+    public java.nio.ByteBuffer getContent() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'content' field.
+         * @param value the value to set.
+     */
+    public void setContent(java.nio.ByteBuffer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'content' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isContentDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'parsedContent' field.
+         */
+    public java.util.List<java.lang.CharSequence> getParsedContent() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'parsedContent' field.
+         * @param value the value to set.
+     */
+    public void setParsedContent(java.util.List<java.lang.CharSequence> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'parsedContent' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isParsedContentDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'outlinks' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getOutlinks() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'outlinks' field.
+         * @param value the value to set.
+     */
+    public void setOutlinks(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'outlinks' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isOutlinksDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'headers' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getHeaders() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'headers' field.
+         * @param value the value to set.
+     */
+    public void setHeaders(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'headers' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isHeadersDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'metadata' field.
+         */
+    public org.apache.gora.examples.generated.Metadata getMetadata() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'metadata' field.
+         * @param value the value to set.
+     */
+    public void setMetadata(org.apache.gora.examples.generated.Metadata value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'metadata' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isMetadataDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'byteData' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.nio.ByteBuffer> getByteData() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'byteData' field.
+         * @param value the value to set.
+     */
+    public void setByteData(java.util.Map<java.lang.CharSequence,java.nio.ByteBuffer> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'byteData' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isByteDataDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'stringData' field.
+         */
+    public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> getStringData() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'stringData' field.
+         * @param value the value to set.
+     */
+    public void setStringData(java.util.Map<java.lang.CharSequence,java.lang.CharSequence> value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'stringData' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isStringDataDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-goraci/src/main/java/org/apache/gora/goraci/generated/CINode.java
+++ b/gora-goraci/src/main/java/org/apache/gora/goraci/generated/CINode.java
@@ -341,7 +341,7 @@ public class CINode extends org.apache.gora.persistency.impl.PersistentBase impl
   }
   
   public CINode.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public CINode newInstance(){
@@ -352,78 +352,78 @@ public class CINode extends org.apache.gora.persistency.impl.PersistentBase impl
   
   public static final class Tombstone extends CINode implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'prev' field.
-		   */
-	  public java.lang.Long getPrev() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'prev' field.
-		   * @param value the value to set.
-	   */
-	  public void setPrev(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'prev' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isPrevDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'client' field.
-		   */
-	  public java.lang.CharSequence getClient() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'client' field.
-		   * @param value the value to set.
-	   */
-	  public void setClient(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'client' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isClientDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'count' field.
-		   */
-	  public java.lang.Long getCount() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'count' field.
-		   * @param value the value to set.
-	   */
-	  public void setCount(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'count' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isCountDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'prev' field.
+         */
+    public java.lang.Long getPrev() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'prev' field.
+         * @param value the value to set.
+     */
+    public void setPrev(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'prev' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isPrevDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'client' field.
+         */
+    public java.lang.CharSequence getClient() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'client' field.
+         * @param value the value to set.
+     */
+    public void setClient(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'client' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isClientDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'count' field.
+         */
+    public java.lang.Long getCount() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'count' field.
+         * @param value the value to set.
+     */
+    public void setCount(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'count' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isCountDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-goraci/src/main/java/org/apache/gora/goraci/generated/Flushed.java
+++ b/gora-goraci/src/main/java/org/apache/gora/goraci/generated/Flushed.java
@@ -222,7 +222,7 @@ public class Flushed extends org.apache.gora.persistency.impl.PersistentBase imp
   }
   
   public Flushed.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public Flushed newInstance(){
@@ -233,32 +233,32 @@ public class Flushed extends org.apache.gora.persistency.impl.PersistentBase imp
   
   public static final class Tombstone extends Flushed implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'count' field.
-		   */
-	  public java.lang.Long getCount() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'count' field.
-		   * @param value the value to set.
-	   */
-	  public void setCount(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'count' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isCountDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'count' field.
+         */
+    public java.lang.Long getCount() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'count' field.
+         * @param value the value to set.
+     */
+    public void setCount(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'count' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isCountDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-tutorial/src/main/java/org/apache/gora/tutorial/log/generated/MetricDatum.java
+++ b/gora-tutorial/src/main/java/org/apache/gora/tutorial/log/generated/MetricDatum.java
@@ -341,7 +341,7 @@ public class MetricDatum extends org.apache.gora.persistency.impl.PersistentBase
   }
   
   public MetricDatum.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public MetricDatum newInstance(){
@@ -352,78 +352,78 @@ public class MetricDatum extends org.apache.gora.persistency.impl.PersistentBase
   
   public static final class Tombstone extends MetricDatum implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'metricDimension' field.
-		   */
-	  public java.lang.CharSequence getMetricDimension() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'metricDimension' field.
-		   * @param value the value to set.
-	   */
-	  public void setMetricDimension(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'metricDimension' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isMetricDimensionDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'timestamp' field.
-		   */
-	  public java.lang.Long getTimestamp() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'timestamp' field.
-		   * @param value the value to set.
-	   */
-	  public void setTimestamp(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'timestamp' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isTimestampDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'metric' field.
-		   */
-	  public java.lang.Long getMetric() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'metric' field.
-		   * @param value the value to set.
-	   */
-	  public void setMetric(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'metric' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isMetricDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'metricDimension' field.
+         */
+    public java.lang.CharSequence getMetricDimension() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'metricDimension' field.
+         * @param value the value to set.
+     */
+    public void setMetricDimension(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'metricDimension' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isMetricDimensionDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'timestamp' field.
+         */
+    public java.lang.Long getTimestamp() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'timestamp' field.
+         * @param value the value to set.
+     */
+    public void setTimestamp(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'timestamp' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isTimestampDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'metric' field.
+         */
+    public java.lang.Long getMetric() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'metric' field.
+         * @param value the value to set.
+     */
+    public void setMetric(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'metric' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isMetricDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter

--- a/gora-tutorial/src/main/java/org/apache/gora/tutorial/log/generated/Pageview.java
+++ b/gora-tutorial/src/main/java/org/apache/gora/tutorial/log/generated/Pageview.java
@@ -640,7 +640,7 @@ public class Pageview extends org.apache.gora.persistency.impl.PersistentBase im
   }
   
   public Pageview.Tombstone getTombstone(){
-  	return TOMBSTONE;
+    return TOMBSTONE;
   }
 
   public Pageview newInstance(){
@@ -651,193 +651,193 @@ public class Pageview extends org.apache.gora.persistency.impl.PersistentBase im
   
   public static final class Tombstone extends Pageview implements org.apache.gora.persistency.Tombstone {
   
-      private Tombstone() { }
+    private Tombstone() { }
   
-	  		  /**
-	   * Gets the value of the 'url' field.
-		   */
-	  public java.lang.CharSequence getUrl() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'url' field.
-		   * @param value the value to set.
-	   */
-	  public void setUrl(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'url' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isUrlDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'timestamp' field.
-		   */
-	  public java.lang.Long getTimestamp() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'timestamp' field.
-		   * @param value the value to set.
-	   */
-	  public void setTimestamp(java.lang.Long value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'timestamp' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isTimestampDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'ip' field.
-		   */
-	  public java.lang.CharSequence getIp() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'ip' field.
-		   * @param value the value to set.
-	   */
-	  public void setIp(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'ip' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isIpDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'httpMethod' field.
-		   */
-	  public java.lang.CharSequence getHttpMethod() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'httpMethod' field.
-		   * @param value the value to set.
-	   */
-	  public void setHttpMethod(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'httpMethod' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isHttpMethodDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'httpStatusCode' field.
-		   */
-	  public java.lang.Integer getHttpStatusCode() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'httpStatusCode' field.
-		   * @param value the value to set.
-	   */
-	  public void setHttpStatusCode(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'httpStatusCode' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isHttpStatusCodeDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'responseSize' field.
-		   */
-	  public java.lang.Integer getResponseSize() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'responseSize' field.
-		   * @param value the value to set.
-	   */
-	  public void setResponseSize(java.lang.Integer value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'responseSize' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isResponseSizeDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'referrer' field.
-		   */
-	  public java.lang.CharSequence getReferrer() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'referrer' field.
-		   * @param value the value to set.
-	   */
-	  public void setReferrer(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'referrer' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isReferrerDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-				  /**
-	   * Gets the value of the 'userAgent' field.
-		   */
-	  public java.lang.CharSequence getUserAgent() {
-	    throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
-	  }
-	
-	  /**
-	   * Sets the value of the 'userAgent' field.
-		   * @param value the value to set.
-	   */
-	  public void setUserAgent(java.lang.CharSequence value) {
-	    throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
-	  }
-	  
-	  /**
-	   * Checks the dirty status of the 'userAgent' field. A field is dirty if it represents a change that has not yet been written to the database.
-		   * @param value the value to set.
-	   */
-	  public boolean isUserAgentDirty() {
-	    throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
-	  }
-	
-		  
+      /**
+     * Gets the value of the 'url' field.
+         */
+    public java.lang.CharSequence getUrl() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'url' field.
+         * @param value the value to set.
+     */
+    public void setUrl(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'url' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isUrlDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'timestamp' field.
+         */
+    public java.lang.Long getTimestamp() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'timestamp' field.
+         * @param value the value to set.
+     */
+    public void setTimestamp(java.lang.Long value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'timestamp' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isTimestampDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'ip' field.
+         */
+    public java.lang.CharSequence getIp() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'ip' field.
+         * @param value the value to set.
+     */
+    public void setIp(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'ip' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isIpDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'httpMethod' field.
+         */
+    public java.lang.CharSequence getHttpMethod() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'httpMethod' field.
+         * @param value the value to set.
+     */
+    public void setHttpMethod(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'httpMethod' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isHttpMethodDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'httpStatusCode' field.
+         */
+    public java.lang.Integer getHttpStatusCode() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'httpStatusCode' field.
+         * @param value the value to set.
+     */
+    public void setHttpStatusCode(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'httpStatusCode' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isHttpStatusCodeDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'responseSize' field.
+         */
+    public java.lang.Integer getResponseSize() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'responseSize' field.
+         * @param value the value to set.
+     */
+    public void setResponseSize(java.lang.Integer value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'responseSize' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isResponseSizeDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'referrer' field.
+         */
+    public java.lang.CharSequence getReferrer() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'referrer' field.
+         * @param value the value to set.
+     */
+    public void setReferrer(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'referrer' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isReferrerDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+        /**
+     * Gets the value of the 'userAgent' field.
+         */
+    public java.lang.CharSequence getUserAgent() {
+      throw new java.lang.UnsupportedOperationException("Get is not supported on tombstones");
+    }
+
+    /**
+     * Sets the value of the 'userAgent' field.
+         * @param value the value to set.
+     */
+    public void setUserAgent(java.lang.CharSequence value) {
+      throw new java.lang.UnsupportedOperationException("Set is not supported on tombstones");
+    }
+  
+    /**
+     * Checks the dirty status of the 'userAgent' field. A field is dirty if it represents a change that has not yet been written to the database.
+         * @param value the value to set.
+     */
+    public boolean isUserAgentDirty() {
+      throw new java.lang.UnsupportedOperationException("IsDirty is not supported on tombstones");
+    }
+
+    
   }
 
   private static final org.apache.avro.io.DatumWriter


### PR DESCRIPTION
Correct GoraCompiler formatting for embedded Tombstone class.

Using spaces instead of tabs. 