### PR TITLE
GORA 616 Fix Multiple slf4j conflict issue

### DIFF
--- a/gora-tutorial/pom.xml
+++ b/gora-tutorial/pom.xml
@@ -111,6 +111,12 @@
     <dependency>
       <groupId>org.apache.gora</groupId>
       <artifactId>gora-couchdb</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -121,6 +127,12 @@
     <dependency>
       <groupId>org.apache.gora</groupId>
       <artifactId>gora-solr</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The issue was the conflict among 
1. log4j-slf4j-impl-2.11.0.jar
2. slf4j-simple-1.6.6.jar
3. slf4j-log4j12-1.6.6.jar
and first two jars were taken from gora-couchdb and gora-solr. 
As a fix, those jars excluded in gora-tutorial/pom.xml dependencies