### PR TITLE
Fix GORA-618 gpg and checksum maven plugin issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -719,20 +719,6 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>${maven-gpg-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <groupId>net.nicoulaj.maven.plugins</groupId>
             <artifactId>checksum-maven-plugin</artifactId>
             <version>${checksum-maven-plugin.version}</version>
@@ -746,19 +732,14 @@
             </executions>
             <configuration>
               <algorithms>
-                <algorithm>MD5</algorithm>
-                <algorithm>SHA-1</algorithm>
                 <algorithm>SHA-512</algorithm>
               </algorithms>
-              <csvSummary>false</csvSummary>
               <fileSets>
                 <fileSet>
                   <directory>${project.build.directory}</directory>
                   <includes>
-                    <include>*.zip</include>
-                    <include>*.tar.gz</include>
-                    <include>*.jar</include>
-                    <include>*.pom</include>
+                    <include>apache-gora-${project.version}-src.zip</include>
+                    <include>apache-gora-${project.version}-src.tar.gz</include>
                   </includes>
                 </fileSet>
               </fileSets>


### PR DESCRIPTION
Unnecessary usages, duplicate runs are removed from releases. maven-gpg-plugin already inherited from Apache Parent pom version 21.