### PR TITLE
GORA-620: Migrate autoflush parameter after HBase refactor

### DIFF
--- a/gora-pig/src/test/resources/gora.properties
+++ b/gora-pig/src/test/resources/gora.properties
@@ -16,4 +16,4 @@
 gora.datastore.default=org.apache.gora.hbase.store.HBaseStore
 gora.datastore.autocreateschema=true
 gora.datastore.scanner.caching=10
-hbase.client.autoflush.default=false
+gora.hbasestore.hbase.client.autoflush.enabled=false


### PR DESCRIPTION
Eg:- gora.hbasestore.hbase.client.autoflush.enabled=true