### PR TITLE
GORA-621: Remove log4j 2 transitive dependencies from solr core

### DIFF
--- a/gora-solr/pom.xml
+++ b/gora-solr/pom.xml
@@ -172,6 +172,22 @@
           <groupId>org.eclipse.jetty.orbit</groupId>
           <artifactId>javax.servlet</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-1.2-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/gora-tutorial/pom.xml
+++ b/gora-tutorial/pom.xml
@@ -127,12 +127,6 @@
     <dependency>
       <groupId>org.apache.gora</groupId>
       <artifactId>gora-solr</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
We observed there are number of log4j dependencies added to classpath due to transitivity.
Until we do a proper log4j upgrade, we should remove log4j 2 dependencies from classpath inheriting from transitive dependencies. Current we have log4j version 1.x.x defined at parent pom and it is used over the entire set of modules. Similar issues reported at [1] due to multiple log4j implementations.

[1] https://issues.apache.org/jira/browse/GORA-616