### PR TITLE
GORA-622 maven-assemly-plugin complains that group id is too big and fails build on macOS Mojave 10.14.6 (18G87)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
             </execution>
           </executions>
           <configuration>
-            <tarLongFileMode>gnu</tarLongFileMode>
+            <tarLongFileMode>posix</tarLongFileMode>
             <finalName>${assembly.finalName}</finalName>
             <descriptors>
               <descriptor>sources-dist/src/main/assembly/src.xml</descriptor>
@@ -845,7 +845,7 @@
     <maven-javadoc-plugin.version>2.8.1</maven-javadoc-plugin.version>
     <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
     <apache-rat-plugin.version>0.8</apache-rat-plugin.version>
-    <maven-assembly-plugin.version>2.5.4</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
     <maven-deploy-plugin.version>2.5</maven-deploy-plugin.version>
     <checksum-maven-plugin.version>1.7</checksum-maven-plugin.version>
     <maven-clean-plugin.version>2.5</maven-clean-plugin.version>


### PR DESCRIPTION
This pr addresses https://issues.apache.org/jira/browse/GORA-622