### PR TITLE
GORA-631 Fix Hive datastore fails testObjectFieldValue test case

### DIFF
--- a/gora-hive/src/test/resources/gora-hive-mapping.xml
+++ b/gora-hive/src/test/resources/gora-hive-mapping.xml
@@ -24,6 +24,7 @@
     <field name="ssn"/>
     <field name="salary"/>
     <field name="webpage"/>
+    <field name="value"/>
   </class>
 
   <class name="org.apache.gora.examples.generated.WebPage" keyClass="java.lang.String" tableName="WebPage">


### PR DESCRIPTION
Hive data store is failing testObjectFieldValue test case as the employee mapping of hive test mapping file doesn't contain a "value" field.
tracked in GORA-631