### PR TITLE
GORA-623 Javadoc build fails with Gora master branch

### DIFF
--- a/gora-cassandra/pom.xml
+++ b/gora-cassandra/pom.xml
@@ -78,9 +78,9 @@
                 <version>${build-helper-maven-plugin.version}</version>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
-                            <goal>add-source</goal>
+                            <goal>add-test-source</goal>
                         </goals>
                         <configuration>
                             <sources>


### PR DESCRIPTION
As discussed in [GORA-623](https://issues.apache.org/jira/projects/GORA/issues/GORA-623), we should avoid generating JavaDocs for generated classes and this patch will add generated classes of Cassandra as test sources. (We have done the same for gora-core)
Build verified.

To address compiler issue [GORA-632](https://issues.apache.org/jira/projects/GORA/issues/GORA-632) is created