### PR TITLE
GORA-647 Use Testcontainers for MongoDB integration tests

### DIFF
--- a/gora-benchmark/pom.xml
+++ b/gora-benchmark/pom.xml
@@ -187,6 +187,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.gora</groupId>
+      <artifactId>gora-mongodb</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Apache CouchDB java client -->
     <dependency>
       <groupId>org.ektorp</groupId>

--- a/gora-benchmark/pom.xml
+++ b/gora-benchmark/pom.xml
@@ -175,8 +175,8 @@
     </dependency>
 
     <dependency>
-      <groupId>de.flapdoodle.embed</groupId>
-      <artifactId>de.flapdoodle.embed.mongo</artifactId>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/gora-mongodb/pom.xml
+++ b/gora-mongodb/pom.xml
@@ -72,6 +72,17 @@
     </testResources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>${build-helper-maven-plugin.version}</version>

--- a/gora-mongodb/pom.xml
+++ b/gora-mongodb/pom.xml
@@ -52,7 +52,6 @@
   <properties>
     <osgi.import>*</osgi.import>
     <osgi.export>org.apache.gora.mongodb*;version="${project.version}";-noimport:=true</osgi.export>
-    <mongo.embed.version>2.2.0</mongo.embed.version>
   </properties>
 
   <build>
@@ -179,9 +178,8 @@
     </dependency>
 
     <dependency>
-      <groupId>de.flapdoodle.embed</groupId>
-      <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>${mongo.embed.version}</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- END of Testing Dependencies -->

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/GoraMongodbTestDriver.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/GoraMongodbTestDriver.java
@@ -19,81 +19,50 @@ package org.apache.gora.mongodb;
 
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
-import de.flapdoodle.embed.mongo.Command;
-import de.flapdoodle.embed.mongo.MongodExecutable;
-import de.flapdoodle.embed.mongo.MongodProcess;
-import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
-import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
-import de.flapdoodle.embed.process.config.io.ProcessOutput;
-import de.flapdoodle.embed.process.runtime.Network;
+import com.mongodb.ServerAddress;
 import org.apache.gora.GoraTestDriver;
 import org.apache.gora.mongodb.store.MongoStore;
 import org.apache.gora.mongodb.store.MongoStoreParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-
 /**
  * Driver to set up an embedded MongoDB database instance for use in our
- * unit tests. We use embedded mongodb which is available from
- * https://github.com/flapdoodle-oss/embedmongo.flapdoodle.de
+ * unit tests. We use testcontainers.org project.
  */
 public class GoraMongodbTestDriver extends GoraTestDriver {
 
   private static Logger log = LoggerFactory
           .getLogger(GoraMongodbTestDriver.class);
 
-  private MongodExecutable _mongodExe;
-  private MongodProcess _mongod;
+  private MongoContainer _container;
   private MongoClient _mongo;
-  private final Version.Main version;
 
   /**
    * Constructor for this class.
    */
-  public GoraMongodbTestDriver() {
-    this(Version.Main.PRODUCTION);
-  }
-
-  public GoraMongodbTestDriver(Version.Main version) {
+  public GoraMongodbTestDriver(MongoContainer startedContainer) {
     super(MongoStore.class);
-    this.version = version;
+    this._container = startedContainer;
   }
 
   /**
    * Initiate the MongoDB server on the default port
    */
   @Override
-  public void setUpClass() throws IOException {
-    IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder()
-            .defaultsWithLogger(Command.MongoD, log)
-            .processOutput(ProcessOutput.getDefaultInstanceSilent())
-            .build();
-
-    MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-
-    int port = Network.getFreeServerPort();
-    IMongodConfig mongodConfig = new MongodConfigBuilder()
-            .version(version)
-            .net(new Net(port, Network.localhostIsIPv6())).build();
+  public void setUpClass() {
+    ServerAddress address = _container.getServerAddress();
+    int port = address.getPort();
+    String host = address.getHost();
 
     // Store Mongo server "host:port" in Hadoop configuration
     // so that MongoStore will be able to get it latter
-    conf.set(MongoStoreParameters.PROP_MONGO_SERVERS, "127.0.0.1:" + port);
+    String mongoServersProp = String.format("%s:%d", host, port);
+    conf.set(MongoStoreParameters.PROP_MONGO_SERVERS, mongoServersProp);
 
     log.info("Starting embedded Mongodb server on {} port.", port);
     try {
-
-      _mongodExe = runtime.prepare(mongodConfig);
-      _mongod = _mongodExe.start();
-
-      _mongo = new MongoClient("localhost", port);
+      _mongo = new MongoClient(address);
     } catch (Exception e) {
       log.error("Error starting embedded Mongodb server... tearing down test driver.");
       tearDownClass();
@@ -106,8 +75,7 @@ public class GoraMongodbTestDriver extends GoraTestDriver {
   @Override
   public void tearDownClass() {
     log.info("Shutting down mongodb server...");
-    _mongod.stop();
-    _mongodExe.stop();
+    _container.stop();
   }
 
   public Mongo getMongo() {

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/GoraMongodbTestDriver.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/GoraMongodbTestDriver.java
@@ -57,8 +57,7 @@ public class GoraMongodbTestDriver extends GoraTestDriver {
 
     // Store Mongo server "host:port" in Hadoop configuration
     // so that MongoStore will be able to get it latter
-    String mongoServersProp = String.format("%s:%d", host, port);
-    conf.set(MongoStoreParameters.PROP_MONGO_SERVERS, mongoServersProp);
+    conf.set(MongoStoreParameters.PROP_MONGO_SERVERS, host + ":" + port);
 
     log.info("Starting embedded Mongodb server on {} port.", port);
     try {

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/MongoContainer.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/MongoContainer.java
@@ -1,8 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.gora.mongodb;
 
 import com.mongodb.ServerAddress;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 
+/**
+ * Use {@link FixedHostPortGenericContainer}
+ * from <a href="https://www.testcontainers.org/">Testcontainers.org</a> project
+ * to handle a MongoDB docker container.
+ */
 public class MongoContainer extends FixedHostPortGenericContainer<MongoContainer> {
 
     public static final int MONGO_PORT = 27017;

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/MongoContainer.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/MongoContainer.java
@@ -1,0 +1,24 @@
+package org.apache.gora.mongodb;
+
+import com.mongodb.ServerAddress;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+
+public class MongoContainer extends FixedHostPortGenericContainer<MongoContainer> {
+
+    public static final int MONGO_PORT = 27017;
+
+    public MongoContainer(String version) {
+        super("mongo:" + version);
+        withExposedPorts(MONGO_PORT);
+    }
+
+    public ServerAddress getServerAddress() {
+        String ipAddress = getContainerIpAddress();
+        int port = getMongoPort();
+        return new ServerAddress(ipAddress, port);
+    }
+
+    public int getMongoPort() {
+        return getMappedPort(MONGO_PORT);
+    }
+}

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/authentications/GoraMongodbAuthenticationTestDriver.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/authentications/GoraMongodbAuthenticationTestDriver.java
@@ -61,9 +61,8 @@ class GoraMongodbAuthenticationTestDriver extends GoraTestDriver {
             ServerAddress address = _container.getServerAddress();
             int port = address.getPort();
             String host = address.getHost();
-            String mongoServersProp = String.format("%s:%d", host, port);
 
-            conf.set(MongoStoreParameters.PROP_MONGO_SERVERS, mongoServersProp);
+            conf.set(MongoStoreParameters.PROP_MONGO_SERVERS, host + ":" + port);
             conf.set(MongoStoreParameters.PROP_MONGO_DB, "admin");
             conf.set(MongoStoreParameters.PROP_MONGO_AUTHENTICATION_TYPE, authMechanisms);
             conf.set(MongoStoreParameters.PROP_MONGO_LOGIN, adminUsername);

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/authentications/PLAIN_AuthenticationTest.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/authentications/PLAIN_AuthenticationTest.java
@@ -17,21 +17,19 @@
  */
 package org.apache.gora.mongodb.authentications;
 
-import de.flapdoodle.embed.mongo.distribution.Version;
-import org.apache.gora.mongodb.GoraMongodbTestDriver;
 import org.apache.gora.mongodb.store.TestMongoStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Perform {@link TestMongoStore} tests on MongoDB 3.2.x server with Plain Authentication mechanism.
+ * Perform {@link TestMongoStore} tests on MongoDB 3.6.x server with Plain Authentication mechanism.
  */
 public class PLAIN_AuthenticationTest extends TestMongoStore {
   private static Logger log = LoggerFactory
           .getLogger(PLAIN_AuthenticationTest.class);
   static {
     try {
-      setTestDriver(new GoraMongodbAuthenticationTestDriver("PLAIN", Version.Main.V3_4));
+      setTestDriver(new GoraMongodbAuthenticationTestDriver("PLAIN", "3.6"));
     } catch (Exception e) {
       log.error("MongoDb Test Driver initialization failed. "+ e.getMessage());
     }

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/authentications/SCRAM_SHA_1_AuthenticationTest.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/authentications/SCRAM_SHA_1_AuthenticationTest.java
@@ -17,20 +17,15 @@
  */
 package org.apache.gora.mongodb.authentications;
 
-import de.flapdoodle.embed.mongo.distribution.Version;
 import org.apache.gora.mongodb.store.TestMongoStore;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-
 /**
- * Perform {@link TestMongoStore} tests on MongoDB 3.2.x server with SCRAM-SHA-1 Authentication mechanism
+ * Perform {@link TestMongoStore} tests on MongoDB 3.6.x server with SCRAM-SHA-1 Authentication mechanism
  */
 public class SCRAM_SHA_1_AuthenticationTest extends TestMongoStore {
   static {
     try {
-      setTestDriver(new GoraMongodbAuthenticationTestDriver("SCRAM-SHA-1", Version.Main.V3_4));
+      setTestDriver(new GoraMongodbAuthenticationTestDriver("SCRAM-SHA-1", "3.6"));
     } catch (Exception e) {
       log.error("MongoDb Test Driver initialization failed. "+ e.getMessage());
     }

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/mapreduce/GoraMongoMapredTest.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/mapreduce/GoraMongoMapredTest.java
@@ -19,14 +19,20 @@ package org.apache.gora.mongodb.mapreduce;
 
 import org.apache.gora.GoraTestDriver;
 import org.apache.gora.mongodb.GoraMongodbTestDriver;
+import org.apache.gora.mongodb.MongoContainer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 /**
  * Created by drazzib on 24/05/14.
  */
 public class GoraMongoMapredTest {
-    protected static GoraTestDriver testDriver = new GoraMongodbTestDriver();
+
+    @ClassRule
+    public final static MongoContainer container = new MongoContainer("3.6");
+
+    protected static GoraTestDriver testDriver = new GoraMongodbTestDriver(container);
 
     @BeforeClass
     public static void setUpClass() throws Exception {

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore34.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore34.java
@@ -17,15 +17,19 @@
  */
 package org.apache.gora.mongodb.store;
 
-import de.flapdoodle.embed.mongo.distribution.Version;
 import org.apache.gora.mongodb.GoraMongodbTestDriver;
+import org.apache.gora.mongodb.MongoContainer;
+import org.junit.ClassRule;
 
 /**
  * Perform {@link TestMongoStore} tests on MongoDB 3.4.x server.
  */
 public class TestMongoStore34 extends TestMongoStore {
 
+  @ClassRule
+  public final static MongoContainer container = new MongoContainer("3.4");
+
   static {
-    setTestDriver(new GoraMongodbTestDriver(Version.Main.V3_4));
+    setTestDriver(new GoraMongodbTestDriver(container));
   }
 }

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore36.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore36.java
@@ -17,15 +17,19 @@
  */
 package org.apache.gora.mongodb.store;
 
-import de.flapdoodle.embed.mongo.distribution.Version;
 import org.apache.gora.mongodb.GoraMongodbTestDriver;
+import org.apache.gora.mongodb.MongoContainer;
+import org.junit.ClassRule;
 
 /**
  * Perform {@link TestMongoStore} tests on MongoDB 3.6.x server.
  */
 public class TestMongoStore36 extends TestMongoStore {
 
+  @ClassRule
+  public final static MongoContainer container = new MongoContainer("3.6");
+
   static {
-    setTestDriver(new GoraMongodbTestDriver(Version.Main.V3_6));
+    setTestDriver(new GoraMongodbTestDriver(container));
   }
 }

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore40.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore40.java
@@ -17,15 +17,19 @@
  */
 package org.apache.gora.mongodb.store;
 
-import de.flapdoodle.embed.mongo.distribution.Version;
 import org.apache.gora.mongodb.GoraMongodbTestDriver;
+import org.apache.gora.mongodb.MongoContainer;
+import org.junit.ClassRule;
 
 /**
  * Perform {@link TestMongoStore} tests on MongoDB 4.0.x server.
  */
 public class TestMongoStore40 extends TestMongoStore {
 
+  @ClassRule
+  public final static MongoContainer container = new MongoContainer("4.0");
+
   static {
-    setTestDriver(new GoraMongodbTestDriver(Version.Main.V4_0));
+    setTestDriver(new GoraMongodbTestDriver(container));
   }
 }

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore42.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStore42.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.mongodb.store;
+
+import org.apache.gora.mongodb.GoraMongodbTestDriver;
+import org.apache.gora.mongodb.MongoContainer;
+import org.junit.ClassRule;
+
+/**
+ * Perform {@link TestMongoStore} tests on MongoDB 4.2.x server.
+ */
+public class TestMongoStore42 extends TestMongoStore {
+
+  @ClassRule
+  public final static MongoContainer container = new MongoContainer("4.2");
+
+  static {
+    setTestDriver(new GoraMongodbTestDriver(container));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1060,6 +1060,12 @@
         <artifactId>gora-mongodb</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.gora</groupId>
+        <artifactId>gora-mongodb</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+      </dependency>
 
       <!--Kudu DataStore dependencies -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -867,7 +867,6 @@
     <couchdb.version>1.4.2</couchdb.version>
 
     <!-- MongoDB Dependencies -->
-    <mongo.embed.version>2.0.0</mongo.embed.version>
     <mongo.driver.version>3.12.2</mongo.driver.version>
 
     <!-- HiveStore Dependencies -->
@@ -1810,13 +1809,6 @@
       </dependency>
 
       <!-- Gora MongoDB Dependencies -->
-      <dependency>
-        <groupId>de.flapdoodle.embed</groupId>
-        <artifactId>de.flapdoodle.embed.mongo</artifactId>
-        <version>${mongo.embed.version}</version>
-        <scope>test</scope>
-      </dependency>
-
       <dependency>
         <groupId>org.mongodb</groupId>
         <artifactId>mongo-java-driver</artifactId>


### PR DESCRIPTION
- Update `gora-mongodb/pom.xml` to use testcontainers    
    * Remove `de.flapdoodle.embed.mongo` dependency
    * Remove `mongo.embed.version` property
    * Add `org.testcontainers` dependency
- Create `MongoContainer` and it as a JUnit `@ClassRule`
- Add new test for MongoDB 4.2
- Refactor `GoraMongodbTestDriver`  
    * Provided container (passed in constructor) to configure Gora properties
- Update `gora-benchmark/pom.xml` to depends on `gora-mongodb:test-jar`
    We can import MongoContainer in GoraClientTest
    (with fixed MongoDB port on localhost)
- Refactor `GoraMongodbAuthenticationTestDriver`
    * Use MongoDB docker container feature to initialize superuser (via environment variables)
    * Pass `--auth` and `--setParameter authenticationMechanisms` as commands
    * Use mongo shell CLI - inside container - to execute script