### PR TITLE
GORA-430 Address use of deprecated API's

### DIFF
--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraClient.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraClient.java
@@ -30,7 +30,6 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
-import com.datastax.driver.core.policies.DowngradingConsistencyRetryPolicy;
 import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
 import com.datastax.driver.core.policies.FallthroughRetryPolicy;
 import com.datastax.driver.core.policies.LatencyAwarePolicy;
@@ -276,24 +275,12 @@ public class CassandraClient {
           break;
         case "DCAwareRoundRobinPolicy": {
           String dataCenter = properties.getProperty(CassandraStoreParameters.DATA_CENTER);
-          boolean allowRemoteDCsForLocalConsistencyLevel = Boolean.parseBoolean(
-                  properties.getProperty(CassandraStoreParameters.ALLOW_REMOTE_DCS_FOR_LOCAL_CONSISTENCY_LEVEL));
           if (dataCenter != null && !dataCenter.isEmpty()) {
-            if (allowRemoteDCsForLocalConsistencyLevel) {
-              builder = builder.withLoadBalancingPolicy(
-                      DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter)
-                              .allowRemoteDCsForLocalConsistencyLevel().build());
-            } else {
-              builder = builder.withLoadBalancingPolicy(
-                      DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter).build());
-            }
+            builder = builder.withLoadBalancingPolicy(
+                    DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter).build());
           } else {
-            if (allowRemoteDCsForLocalConsistencyLevel) {
-              builder = builder.withLoadBalancingPolicy(
-                      (DCAwareRoundRobinPolicy.builder().allowRemoteDCsForLocalConsistencyLevel().build()));
-            } else {
-              builder = builder.withLoadBalancingPolicy((DCAwareRoundRobinPolicy.builder().build()));
-            }
+            builder = builder.withLoadBalancingPolicy(
+                    (DCAwareRoundRobinPolicy.builder().build()));
           }
           break;
         }
@@ -302,25 +289,12 @@ public class CassandraClient {
           break;
         case "TokenAwareDCAwareRoundRobinPolicy": {
           String dataCenter = properties.getProperty(CassandraStoreParameters.DATA_CENTER);
-          boolean allowRemoteDCsForLocalConsistencyLevel = Boolean.parseBoolean(
-                  properties.getProperty(CassandraStoreParameters.ALLOW_REMOTE_DCS_FOR_LOCAL_CONSISTENCY_LEVEL));
           if (dataCenter != null && !dataCenter.isEmpty()) {
-            if (allowRemoteDCsForLocalConsistencyLevel) {
-              builder = builder.withLoadBalancingPolicy(new TokenAwarePolicy(
-                      DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter)
-                              .allowRemoteDCsForLocalConsistencyLevel().build()));
-            } else {
-              builder = builder.withLoadBalancingPolicy(new TokenAwarePolicy(
-                      DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter).build()));
-            }
+            builder = builder.withLoadBalancingPolicy(new TokenAwarePolicy(
+                    DCAwareRoundRobinPolicy.builder().withLocalDc(dataCenter).build()));
           } else {
-            if (allowRemoteDCsForLocalConsistencyLevel) {
-              builder = builder.withLoadBalancingPolicy(new TokenAwarePolicy(
-                      DCAwareRoundRobinPolicy.builder().allowRemoteDCsForLocalConsistencyLevel().build()));
-            } else {
-              builder = builder.withLoadBalancingPolicy(
-                      new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().build()));
-            }
+            builder = builder.withLoadBalancingPolicy(new TokenAwarePolicy(
+                    DCAwareRoundRobinPolicy.builder().build()));
           }
           break;
         }
@@ -429,17 +403,11 @@ public class CassandraClient {
         case "DefaultRetryPolicy":
           builder = builder.withRetryPolicy(DefaultRetryPolicy.INSTANCE);
           break;
-        case "DowngradingConsistencyRetryPolicy":
-          builder = builder.withRetryPolicy(DowngradingConsistencyRetryPolicy.INSTANCE);
-          break;
         case "FallthroughRetryPolicy":
           builder = builder.withRetryPolicy(FallthroughRetryPolicy.INSTANCE);
           break;
         case "LoggingDefaultRetryPolicy":
           builder = builder.withRetryPolicy(new LoggingRetryPolicy(DefaultRetryPolicy.INSTANCE));
-          break;
-        case "LoggingDowngradingConsistencyRetryPolicy":
-          builder = builder.withRetryPolicy(new LoggingRetryPolicy(DowngradingConsistencyRetryPolicy.INSTANCE));
           break;
         case "LoggingFallthroughRetryPolicy":
           builder = builder.withRetryPolicy(new LoggingRetryPolicy(FallthroughRetryPolicy.INSTANCE));

--- a/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStoreParameters.java
+++ b/gora-cassandra/src/main/java/org/apache/gora/cassandra/store/CassandraStoreParameters.java
@@ -154,8 +154,8 @@ public class CassandraStoreParameters {
   public static final String EXPONENTIAL_RECONNECTION_POLICY_MAX_DELAY = "gora.cassandrastore.exponentialReconnectionPolicyMaxDelay";
   /**
    * Property pointing to set the retry policy.
-   * "DefaultRetryPolicy", "DowngradingConsistencyRetryPolicy", "FallthroughRetryPolicy",
-   * "LoggingDefaultRetryPolicy", "LoggingDowngradingConsistencyRetryPolicy", "LoggingFallthroughRetryPolicy"
+   * "DefaultRetryPolicy", "FallthroughRetryPolicy",
+   * "LoggingDefaultRetryPolicy", "LoggingFallthroughRetryPolicy"
    */
   public static final String RETRY_POLICY = "gora.cassandrastore.retryPolicy";
   /**
@@ -208,11 +208,6 @@ public class CassandraStoreParameters {
    * string
    */
   public static final String DATA_CENTER = "gora.cassandrastore.dataCenter";
-  /**
-   * Property pointing to enable/disable remote data centers for local consistency level.
-   * string
-   */
-  public static final String ALLOW_REMOTE_DCS_FOR_LOCAL_CONSISTENCY_LEVEL = "gora.cassandrastore.allowRemoteDCsForLocalConsistencyLevel";
   /**
    * Property pointing to use Native Cassandra Native Serialization.
    * avro/ native

--- a/gora-compiler/src/main/java/org/apache/gora/compiler/GoraCompiler.java
+++ b/gora-compiler/src/main/java/org/apache/gora/compiler/GoraCompiler.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
@@ -294,18 +295,16 @@ public class GoraCompiler extends SpecificCompiler {
     List<Field> newFields = new ArrayList<>();
     byte[] defaultDirtyBytesValue = new byte[getNumberOfBytesNeededForDirtyBits(originalSchema)];
     Arrays.fill(defaultDirtyBytesValue, (byte) 0);
-    JsonNode defaultDirtyJsonValue = JsonNodeFactory.instance
-      .binaryNode(defaultDirtyBytesValue);
     Field dirtyBits = new Field(DIRTY_BYTES_FIELD_NAME,
       Schema.create(Type.BYTES),
       "Bytes used to represent weather or not a field is dirty.",
-      defaultDirtyJsonValue);
+      defaultDirtyBytesValue);
     newFields.add(dirtyBits);
     for (Field originalField : originalFields) {
       // recursively add dirty support
       Field newField = new Field(originalField.name(),
         getSchemaWithDirtySupport(originalField.schema(),queue),
-        originalField.doc(), originalField.defaultValue(),
+        originalField.doc(), originalField.defaultVal(),
         originalField.order());
       newFields.add(newField);
     }

--- a/gora-couchdb/src/main/java/org/apache/gora/couchdb/store/CouchDBStore.java
+++ b/gora-couchdb/src/main/java/org/apache/gora/couchdb/store/CouchDBStore.java
@@ -138,7 +138,7 @@ public class CouchDBStore<K, T extends PersistentBase> extends DataStoreBase<K, 
       mapping = builder.build();
 
       final ObjectMapperFactory myObjectMapperFactory = new CouchDBObjectMapperFactory();
-      myObjectMapperFactory.createObjectMapper().addMixInAnnotations(persistentClass, CouchDbDocument.class);
+      myObjectMapperFactory.createObjectMapper().addMixIn(persistentClass, CouchDbDocument.class);
 
       db = new StdCouchDbConnector(mapping.getDatabaseName(), dbInstance, myObjectMapperFactory);
       db.createDatabaseIfNotExists();

--- a/gora-goraci/src/main/java/org/apache/gora/goraci/Generator.java
+++ b/gora-goraci/src/main/java/org/apache/gora/goraci/Generator.java
@@ -318,9 +318,9 @@ public class Generator extends Configured implements Tool {
 
   public int run(int numMappers, long numNodes, boolean concurrent) throws Exception {
     LOG.info("Running Generator with numMappers={}, numNodes={}", numMappers, numNodes);
-    
-    Job job = new Job(getConf());
-    
+
+    Job job = Job.getInstance(getConf());
+
     job.setJobName("Link Generator");
     job.setNumReduceTasks(0);
     job.setJarByClass(getClass());

--- a/gora-goraci/src/main/java/org/apache/gora/goraci/Verify.java
+++ b/gora-goraci/src/main/java/org/apache/gora/goraci/Verify.java
@@ -196,7 +196,7 @@ public class Verify extends Configured implements Tool {
     
     DataStore<Long,CINode> store = DataStoreFactory.getDataStore(Long.class, CINode.class, new Configuration());
 
-    job = new Job(getConf());
+    job = Job.getInstance(getConf());
     
     if (!job.getConfiguration().get("io.serializations").contains("org.apache.hadoop.io.serializer.JavaSerialization")) {
       job.getConfiguration().set("io.serializations", job.getConfiguration().get("io.serializations") + ",org.apache.hadoop.io.serializer.JavaSerialization");

--- a/gora-goraci/src/main/java/org/apache/gora/goraci/rackspace/RackspaceOrchestration.java
+++ b/gora-goraci/src/main/java/org/apache/gora/goraci/rackspace/RackspaceOrchestration.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.apache.gora.memory.store.MemStore;
 import org.apache.gora.store.DataStoreFactory;
 import org.jclouds.ContextBuilder;
-import org.jclouds.chef.ChefContext;
 import org.jclouds.chef.config.ChefProperties;
 import org.jclouds.chef.domain.BootstrapConfig;
 import org.jclouds.chef.domain.CookbookVersion;

--- a/gora-infinispan/src/test/java/org/apache/gora/infinispan/SimulationDriver.java
+++ b/gora-infinispan/src/test/java/org/apache/gora/infinispan/SimulationDriver.java
@@ -106,7 +106,6 @@ public class SimulationDriver extends MultipleCacheManagersTest {
     // Create appropriate caches at each node.
     ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
     builder.indexing()
-    .enable()
     .index(Index.LOCAL)
     .addProperty("default.directory_provider", "ram")
     .addProperty("hibernate.search.default.exclusive_index_use","true")

--- a/gora-tutorial/src/main/java/org/apache/gora/tutorial/log/LogAnalytics.java
+++ b/gora-tutorial/src/main/java/org/apache/gora/tutorial/log/LogAnalytics.java
@@ -137,7 +137,7 @@ public class LogAnalytics extends Configured implements Tool {
    */
   public Job createJob(DataStore<Long, Pageview> inStore,
       DataStore<String, MetricDatum> outStore, int numReducer) throws IOException {
-    Job job = new Job(getConf());
+    Job job = Job.getInstance(getConf());
     job.setJobName("Log Analytics");
     log.info("Creating Hadoop Job: {}", job.getJobName());
     job.setNumReduceTasks(numReducer);


### PR DESCRIPTION
There are a couple of issues I faced with:
1) Is it ok to remove `allowRemoteDCsForLocalConsistencyLevel` completely like I did? The docs say "DC failover shouldn't be done in the driver, which does not have the necessary context to know what makes sense considering application semantics", so it probably does not make sense to keep this as an option in gora.
2) Datastax developers [decided to remove](https://docs.datastax.com/en/developer/java-driver/3.5/upgrade_guide/#3-5-0) `DowngradingConsistencyRetryPolicy` adding that users will now have to implement this logic themselves. It is probably possible to implement something analogous to their [example](https://github.com/datastax/java-driver/blob/3.x/driver-examples/src/main/java/com/datastax/driver/examples/retry/DowngradingRetry.java), but I think that  its impementation is out of this ticket's scope, so I just removed it too.