### PR TITLE
GORA-667 Revert GORA-271 changes in hbase-store 

### DIFF
--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseMapping.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseMapping.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
@@ -199,5 +200,18 @@ public class HBaseMapping {
     }
     return strBuilder.toString() ;
   }
-  
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    HBaseMapping that = (HBaseMapping) o;
+    return Objects.equals(tableDescriptor, that.tableDescriptor) &&
+            Objects.equals(columnMap, that.columnMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tableDescriptor, columnMap);
+  }
 }

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -828,7 +828,7 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
   }
 
   @SuppressWarnings("unchecked")
-  private HBaseMapping readMapping(InputStream mappingStream) throws IOException {
+  public HBaseMapping readMapping(InputStream mappingStream) throws IOException {
 
     HBaseMappingBuilder mappingBuilder = new HBaseMappingBuilder();
 

--- a/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
+++ b/gora-hbase/src/main/java/org/apache/gora/hbase/store/HBaseStore.java
@@ -898,10 +898,8 @@ public class HBaseStore<K, T extends PersistentBase> extends DataStoreBase<K, T>
         throw new ConfigurationException("Gora-hbase-mapping does not include the name and keyClass in the databean.");
       }
     } catch (MalformedURLException ex) {
-      LOG.error("Error while trying to read the mapping file {}. "
-              + "Expected to be in the classpath "
-              + "(ClassLoader#getResource(java.lang.String)).",
-              mappingStream) ;
+      LOG.error("Error while trying to read the mapping. "
+              + "Mapping was not found.");
       LOG.error("Actual classpath = {}", Arrays.asList(
           ((URLClassLoader) getClass().getClassLoader()).getURLs()));
       throw ex ;

--- a/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStoreMappingFromProperties.java
+++ b/gora-hbase/src/test/java/org/apache/gora/hbase/store/TestHBaseStoreMappingFromProperties.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gora.hbase.store;
+
+import junit.framework.Assert;
+import org.apache.commons.io.IOUtils;
+import org.apache.gora.examples.generated.Employee;
+import org.apache.gora.hbase.util.HBaseClusterSingleton;
+import org.apache.gora.store.DataStoreFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Properties;
+
+/**
+ * Test case for loading mappings from properties
+ */
+public class TestHBaseStoreMappingFromProperties {
+    private HBaseClusterSingleton cluster;
+
+    @Before
+    public void setUp() {
+        // Cluster for HBaseStore
+        cluster = HBaseClusterSingleton.build(1);
+    }
+
+    @Test
+    public void testInitialize() throws IOException {
+        // Simple mapping XML
+        String mappingXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<gora-otd>\n" +
+                "\n" +
+                "  <table name=\"Employee\">\n" +
+                "    <family name=\"info\"/>\n" +
+                "  </table>\n" +
+                "    <class name=\"org.apache.gora.examples.generated.Employee\" keyClass=\"java.lang.String\" table=\"Employee\">\n" +
+                "    <field name=\"name\" family=\"info\" qualifier=\"nm\"/>\n" +
+                "    </class>\n" +
+                "</gora-otd>";
+
+        Configuration conf = HBaseConfiguration.create(cluster.getHbaseTestingUtil().getConfiguration());
+        Properties prop = DataStoreFactory.createProps();
+
+        // Set mapping XML property
+        prop.setProperty(HBaseStore.XML_MAPPING_DEFINITION, mappingXml);
+        HBaseStore<String, Employee> hBaseStore =
+                DataStoreFactory.createDataStore(HBaseStore.class, String.class, Employee.class, conf, prop);
+        HBaseMapping actualMapping = hBaseStore.getMapping();
+
+        // Read mapping definition from mappingXml
+        HBaseMapping expectedMapping = hBaseStore.readMapping(IOUtils.toInputStream(mappingXml, (Charset) null));
+
+        Assert.assertEquals(expectedMapping, actualMapping);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        cluster.shutdownMiniCluster();
+    }
+}


### PR DESCRIPTION
This PR still uses DataStoreFactory.getMappingFile() method, when retrieving the filename for the mapping file from the properties file, but also allows to load mappings from properties instead of only from files. 