### PR TITLE
[GORA-665] - Add support for the Ignite datastore in GoraExplorer

### DIFF
--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteMappingBuilder.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteMappingBuilder.java
@@ -75,20 +75,19 @@ public class IgniteMappingBuilder<K, T extends PersistentBase> {
   /**
    * Reads Ignite mappings from file
    *
-   * @param mappingFile File name relative to the resource's classpath
+   * @param inputStream Input stream of the mapping
    */
-  public void readMappingFile(String mappingFile) {
+  public void readMappingFile(InputStream inputStream) {
     try {
       SAXBuilder saxBuilder = new SAXBuilder();
-      InputStream inputStream = getClass().getClassLoader().getResourceAsStream(mappingFile);
       if (inputStream == null) {
-        LOG.error("Mapping file '{}' could not be found!", mappingFile);
-        throw new IOException("Mapping file '" + mappingFile + "' could not be found!");
+        LOG.error("The mapping input stream is null!");
+        throw new IOException("The mapping input stream is null!");
       }
       Document document = saxBuilder.build(inputStream);
       if (document == null) {
-        LOG.error("Mapping file '{}' could not be found!", mappingFile);
-        throw new IOException("Mapping file '" + mappingFile + "' could not be found!");
+        LOG.error("The mapping document is null!");
+        throw new IOException("The mapping document is null!");
       }
       @SuppressWarnings("unchecked")
       List<Element> classes = document.getRootElement().getChildren("class");

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStore.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStore.java
@@ -91,7 +91,7 @@ public class IgniteStore<K, T extends PersistentBase> extends DataStoreBase<K, T
       builder.readMappingFile(mappingStream);
       igniteMapping = builder.getIgniteMapping();
       igniteParameters = IgniteParameters.load(properties);
-      connection = acquireConnection();
+      connection = acquireConnection(this.igniteParameters);
       LOG.info("Ignite store was successfully initialized");
       if (!schemaExists()) {
         createSchema();
@@ -102,7 +102,7 @@ public class IgniteStore<K, T extends PersistentBase> extends DataStoreBase<K, T
     }
   }
 
-  private Connection acquireConnection() throws ClassNotFoundException, SQLException {
+  public static Connection acquireConnection(IgniteParameters igniteParameters) throws ClassNotFoundException, SQLException {
     Class.forName(IgniteBackendConstants.DRIVER_NAME);
     StringBuilder urlBuilder = new StringBuilder();
     urlBuilder.append(IgniteBackendConstants.JDBC_PREFIX);

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStoreMetadataAnalyzer.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStoreMetadataAnalyzer.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.ignite.store;
+
+import avro.shaded.com.google.common.collect.Lists;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+import org.apache.gora.ignite.utils.IgniteSQLBuilder;
+import org.apache.gora.store.DataStoreFactory;
+import org.apache.gora.store.impl.DataStoreMetadataAnalyzer;
+import org.apache.gora.util.GoraException;
+
+public class IgniteStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
+
+  private IgniteParameters igniteParameters;
+  private Connection connection;
+
+  @Override
+  public void initialize() throws GoraException {
+    try {
+      Properties createProps = DataStoreFactory.createProps();
+      igniteParameters = IgniteParameters.load(createProps);
+      connection = IgniteStore.acquireConnection(igniteParameters);
+    } catch (ClassNotFoundException | SQLException ex) {
+      throw new GoraException(ex);
+    }
+  }
+
+  @Override
+  public String getType() {
+    return "IGNITE";
+  }
+
+  @Override
+  public List<String> getTablesNames() throws GoraException {
+    List<String> tabs = Lists.newArrayList();
+    try (Statement stmt = connection.createStatement()) {
+      ResultSet executeQuery = stmt.executeQuery(IgniteSQLBuilder.createSelectAllTablesNames(igniteParameters.getSchema()));
+      while (executeQuery.next()) {
+        tabs.add(executeQuery.getString(1));
+      }
+      executeQuery.close();
+    } catch (SQLException ex) {
+      throw new GoraException(ex);
+    }
+    return tabs;
+  }
+
+  @Override
+  public IgniteTableMetadata getTableInfo(String tableName) throws GoraException {
+    HashMap<String, String> hmap = new HashMap();
+    String pkdt = "";
+    try (Statement stmt = connection.createStatement()) {
+      ResultSet executeQuery = stmt.executeQuery(IgniteSQLBuilder.createSelectAllColumnsOfTable(igniteParameters.getSchema(), tableName));
+      while (executeQuery.next()) {
+        hmap.put(executeQuery.getString(1), executeQuery.getString(2));
+        pkdt = executeQuery.getBoolean(3) ? executeQuery.getString(1) : pkdt;
+      }
+      executeQuery.close();
+    } catch (SQLException ex) {
+      throw new GoraException(ex);
+    }
+    /**
+     * Special columns. Ignite uses _KEY column to represent primary key. Ignite
+     * uses _VAL column to represent value.
+     */
+    hmap.remove("_KEY");
+    hmap.remove("_VAL");
+    return new IgniteTableMetadata(pkdt, hmap);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      if (connection != null) {
+        connection.close();
+      }
+    } catch (SQLException ex) {
+      throw new IOException(ex);
+    }
+  }
+
+}

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStoreMetadataAnalyzer.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteStoreMetadataAnalyzer.java
@@ -70,12 +70,18 @@ public class IgniteStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
   @Override
   public IgniteTableMetadata getTableInfo(String tableName) throws GoraException {
     HashMap<String, String> hmap = new HashMap();
+    String pkcl = "";
     String pkdt = "";
     try (Statement stmt = connection.createStatement()) {
       ResultSet executeQuery = stmt.executeQuery(IgniteSQLBuilder.createSelectAllColumnsOfTable(igniteParameters.getSchema(), tableName));
       while (executeQuery.next()) {
-        hmap.put(executeQuery.getString(1), executeQuery.getString(2));
-        pkdt = executeQuery.getBoolean(3) ? executeQuery.getString(1) : pkdt;
+        if (executeQuery.getBoolean(3)) {
+          pkcl = executeQuery.getString(1);
+          pkdt = executeQuery.getString(2);
+        } else {
+          hmap.put(executeQuery.getString(1), executeQuery.getString(2));
+        }
+
       }
       executeQuery.close();
     } catch (SQLException ex) {
@@ -87,7 +93,7 @@ public class IgniteStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
      */
     hmap.remove("_KEY");
     hmap.remove("_VAL");
-    return new IgniteTableMetadata(pkdt, hmap);
+    return new IgniteTableMetadata(pkcl, pkdt, hmap);
   }
 
   @Override

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteTableMetadata.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteTableMetadata.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.ignite.store;
+
+import java.util.Map;
+
+public class IgniteTableMetadata {
+
+  //Primary key
+  private String primaryKey;
+  //Pairs Column Name, Datatype
+  private Map<String, String> columns;
+
+  public IgniteTableMetadata(String primaryKey, Map<String, String> columns) {
+    this.primaryKey = primaryKey;
+    this.columns = columns;
+  }
+
+  public String getPrimaryKey() {
+    return primaryKey;
+  }
+
+  public void setPrimaryKey(String primaryKey) {
+    this.primaryKey = primaryKey;
+  }
+
+  public Map<String, String> getColumns() {
+    return columns;
+  }
+
+  public void setColumns(Map<String, String> columns) {
+    this.columns = columns;
+  }
+
+}

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteTableMetadata.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/store/IgniteTableMetadata.java
@@ -20,14 +20,25 @@ import java.util.Map;
 
 public class IgniteTableMetadata {
 
-  //Primary key
+  //Primary key Column
   private String primaryKey;
+  //Primary key type
+  private String primaryKeyType;
   //Pairs Column Name, Datatype
   private Map<String, String> columns;
 
-  public IgniteTableMetadata(String primaryKey, Map<String, String> columns) {
+  public IgniteTableMetadata(String primaryKey, String primaryKeyType, Map<String, String> columns) {
     this.primaryKey = primaryKey;
+    this.primaryKeyType = primaryKeyType;
     this.columns = columns;
+  }
+
+  public String getPrimaryKeyType() {
+    return primaryKeyType;
+  }
+
+  public void setPrimaryKeyType(String primaryKeyType) {
+    this.primaryKeyType = primaryKeyType;
   }
 
   public String getPrimaryKey() {

--- a/gora-ignite/src/main/java/org/apache/gora/ignite/utils/IgniteSQLBuilder.java
+++ b/gora-ignite/src/main/java/org/apache/gora/ignite/utils/IgniteSQLBuilder.java
@@ -377,4 +377,43 @@ public class IgniteSQLBuilder {
     }
   }
 
+  /**
+   * Returns a SQL statement for returning a list of tables
+   */
+  public static String createSelectAllTablesNames(String schemaIgnite) {
+    DbSpec spec = new DbSpec();
+    DbSchema schema = spec.addDefaultSchema();
+    DbTable aTable = schema.addTable("SYS.TABLES");
+    SelectQuery selectQuery = new SelectQuery();
+    DbColumn[] lsColumns = new DbColumn[]{aTable.addColumn("TABLE_NAME")};
+    selectQuery.addColumns(lsColumns);
+    selectQuery.addFromTable(aTable);
+    return selectQuery.validate().toString();
+  }
+
+  /**
+   * Returns a SQL statement for metadata of a table
+   */
+  public static String createSelectAllColumnsOfTable(String schemaIgnite, String table) {
+    DbSpec spec = new DbSpec();
+    DbSchema schema = spec.addDefaultSchema();
+    DbTable aTable = schema.addTable("INFORMATION_SCHEMA.COLUMNS");
+    DbTable aTable2 = schema.addTable("SYS.TABLE_COLUMNS");
+    SelectQuery selectQuery = new SelectQuery();
+    DbColumn[] lsColumns = new DbColumn[]{aTable.addColumn("COLUMN_NAME"),
+      aTable.addColumn("TYPE_NAME"), aTable2.addColumn("PK")};
+    selectQuery.addColumns(lsColumns);
+    selectQuery.addFromTable(aTable);
+    selectQuery.addFromTable(aTable2);
+    selectQuery.addCondition(new BinaryCondition(BinaryCondition.Op.EQUAL_TO,
+            new DbColumn(aTable, "TABLE_SCHEMA", null),
+            schemaIgnite));
+    selectQuery.addCondition(new BinaryCondition(BinaryCondition.Op.EQUAL_TO,
+            new DbColumn(aTable, "TABLE_NAME", null),
+            table));
+    selectQuery.addCondition(new BinaryCondition(BinaryCondition.Op.EQUAL_TO,
+            new DbColumn(aTable, "COLUMN_NAME", null),
+            new DbColumn(aTable2, "COLUMN_NAME", null)));
+    return selectQuery.validate().toString();
+  }
 }

--- a/gora-ignite/src/test/java/org/apache/gora/ignite/store/TestIgniteStore.java
+++ b/gora-ignite/src/test/java/org/apache/gora/ignite/store/TestIgniteStore.java
@@ -41,13 +41,13 @@ public class TestIgniteStore extends DataStoreTestBase {
     Assert.assertEquals("Ignite Store Metadata Type", "IGNITE", createAnalyzer.getType());
     Assert.assertTrue("Ignite Store Metadata Table Names", createAnalyzer.getTablesNames().equals(Lists.newArrayList("WEBPAGE", "EMPLOYEE")));
     IgniteTableMetadata tableInfo = (IgniteTableMetadata) createAnalyzer.getTableInfo("EMPLOYEE");
-    Assert.assertEquals("Ignite Store Metadata Table Primary Key", "PKSSN", tableInfo.getPrimaryKey());
+    Assert.assertEquals("Ignite Store Metadata Table Primary Key Column", "PKSSN", tableInfo.getPrimaryKey());
+    Assert.assertEquals("Ignite Store Metadata Table Primary Key Type", "VARCHAR", tableInfo.getPrimaryKeyType());
     HashMap<String, String> hmap = new HashMap();
     hmap.put("WEBPAGE", "VARBINARY");
     hmap.put("BOSS", "VARBINARY");
     hmap.put("SALARY", "INTEGER");
     hmap.put("DATEOFBIRTH", "BIGINT");
-    hmap.put("PKSSN", "VARCHAR");
     hmap.put("VALUE", "VARCHAR");
     hmap.put("NAME", "VARCHAR");
     hmap.put("SSN", "VARCHAR");

--- a/gora-ignite/src/test/java/org/apache/gora/ignite/store/TestIgniteStore.java
+++ b/gora-ignite/src/test/java/org/apache/gora/ignite/store/TestIgniteStore.java
@@ -17,8 +17,14 @@
  */
 package org.apache.gora.ignite.store;
 
+import java.util.HashMap;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 import org.apache.gora.ignite.GoraIgniteTestDriver;
+import org.apache.gora.store.DataStoreMetadataFactory;
 import org.apache.gora.store.DataStoreTestBase;
+import org.apache.gora.store.impl.DataStoreMetadataAnalyzer;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Test case for IgniteStore.
@@ -27,6 +33,25 @@ public class TestIgniteStore extends DataStoreTestBase {
 
   static {
     setTestDriver(new GoraIgniteTestDriver());
+  }
+
+  @Test
+  public void igniteStoreMetadataAnalyzerTest() throws Exception {
+    DataStoreMetadataAnalyzer createAnalyzer = DataStoreMetadataFactory.createAnalyzer(DataStoreTestBase.testDriver.getConfiguration());
+    Assert.assertEquals("Ignite Store Metadata Type", "IGNITE", createAnalyzer.getType());
+    Assert.assertTrue("Ignite Store Metadata Table Names", createAnalyzer.getTablesNames().equals(Lists.newArrayList("WEBPAGE", "EMPLOYEE")));
+    IgniteTableMetadata tableInfo = (IgniteTableMetadata) createAnalyzer.getTableInfo("EMPLOYEE");
+    Assert.assertEquals("Ignite Store Metadata Table Primary Key", "PKSSN", tableInfo.getPrimaryKey());
+    HashMap<String, String> hmap = new HashMap();
+    hmap.put("WEBPAGE", "VARBINARY");
+    hmap.put("BOSS", "VARBINARY");
+    hmap.put("SALARY", "INTEGER");
+    hmap.put("DATEOFBIRTH", "BIGINT");
+    hmap.put("PKSSN", "VARCHAR");
+    hmap.put("VALUE", "VARCHAR");
+    hmap.put("NAME", "VARCHAR");
+    hmap.put("SSN", "VARCHAR");
+    Assert.assertTrue("Ignite Store Metadata Table Columns", tableInfo.getColumns().equals(hmap));
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -826,7 +826,7 @@
     <cassandra-driver.version>3.9.0</cassandra-driver.version>
     <cassandra.version>3.11.0</cassandra.version>
     <!-- Ignite Dependencies -->
-    <ignite.version>2.6.0</ignite.version>
+    <ignite.version>2.9.0</ignite.version>
     <sqlbuilder.version>2.1.7</sqlbuilder.version>
     <!-- Redis Dependencies -->
     <redisson.version>3.11.0</redisson.version>


### PR DESCRIPTION
To add support for Apache Ignite in Gora Explorer the mapping XML must be read from gora.mapping in the same way as is implemented in the Kudu datastore.