### PR TITLE
GORA-557 Add support for MongoDB to GoraExplorer

### DIFF
--- a/gora-core/src/main/java/org/apache/gora/store/DataStoreMetadataFactory.java
+++ b/gora-core/src/main/java/org/apache/gora/store/DataStoreMetadataFactory.java
@@ -91,6 +91,7 @@ public class DataStoreMetadataFactory {
     try {
       DataStoreMetadataAnalyzer metadataAnalyzer = (DataStoreMetadataAnalyzer) ReflectionUtils.newInstance(metadataAnalyzerClassName);
       metadataAnalyzer.setConf(configuration);
+      metadataAnalyzer.setProperties(properties);
       metadataAnalyzer.initialize();
       return metadataAnalyzer;
     } catch (ClassNotFoundException e) {

--- a/gora-core/src/main/java/org/apache/gora/store/impl/DataStoreMetadataAnalyzer.java
+++ b/gora-core/src/main/java/org/apache/gora/store/impl/DataStoreMetadataAnalyzer.java
@@ -19,6 +19,7 @@ package org.apache.gora.store.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.gora.util.GoraException;
 import org.apache.hadoop.conf.Configurable;
@@ -42,6 +43,11 @@ public abstract class DataStoreMetadataAnalyzer implements Configurable {
    * Configuration from Hadoop/HBase/...
    */
   protected Configuration conf;
+
+  /**
+   * Properties for the data store.
+   */
+  protected Properties properties;
   
   /**
    * After been set the configuratin, this method is called.
@@ -83,5 +89,13 @@ public abstract class DataStoreMetadataAnalyzer implements Configurable {
   @Override
   public Configuration getConf() {
     return conf;
+  }
+
+  public Properties getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Properties properties) {
+    this.properties = properties;
   }
 }

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoMapping.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoMapping.java
@@ -21,6 +21,7 @@ import static org.apache.gora.mongodb.store.MongoMapping.DocumentFieldType.*;
 
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -217,5 +218,21 @@ public class MongoMapping {
     LIST, // a list
     DOCUMENT, // a subdocument
     OBJECTID // ObjectId is a 12-byte BSON type
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MongoMapping mapping = (MongoMapping) o;
+    return Objects.equals(collectionName, mapping.collectionName) &&
+            Objects.equals(classToDocument, mapping.classToDocument) &&
+            Objects.equals(documentToClass, mapping.documentToClass) &&
+            Objects.equals(documentFields, mapping.documentFields);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(collectionName, classToDocument, documentToClass, documentFields);
   }
 }

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoMappingBuilder.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoMappingBuilder.java
@@ -79,22 +79,18 @@ public class MongoMappingBuilder<K, T extends PersistentBase> {
   }
 
   /**
-   * Load the {@link org.apache.gora.mongodb.store.MongoMapping} from a file
+   * Load the {@link org.apache.gora.mongodb.store.MongoMapping} from an input stream
    * passed in parameter.
    * 
-   * @param uri
-   *          path to the file holding the mapping
+   * @param is
+   *          input stream holding the mapping
    * @throws java.io.IOException
    */
-  protected void fromFile(String uri) throws IOException {
+  protected void fromInputStream(InputStream is) throws IOException {
     try {
       SAXBuilder saxBuilder = new SAXBuilder();
-      InputStream is = getClass().getResourceAsStream(uri);
       if (is == null) {
-        String msg = "Unable to load the mapping from resource '" + uri
-            + "' as it does not appear to exist! " + "Trying local file.";
-        MongoStore.LOG.warn(msg);
-        is = new FileInputStream(uri);
+        throw new IllegalArgumentException("The mapping input stream is null!");
       }
       Document doc = saxBuilder.build(is);
       Element root = doc.getRootElement();

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStore.java
@@ -174,7 +174,7 @@ DataStoreBase<K, T> {
    *               connecting to remote MongoDB.
    * @return a {@link com.mongodb.client.MongoClient} instance connected to the server
    */
-  private com.mongodb.client.MongoClient getClient(MongoStoreParameters params) {
+  public static com.mongodb.client.MongoClient getClient(MongoStoreParameters params) {
 
     // Utf8 serialization!
     CodecRegistry codecRegistry = CodecRegistries.fromRegistries(
@@ -231,7 +231,7 @@ DataStoreBase<K, T> {
    * @return Mongo Crendential
    * @see <a href="http://api.mongodb.com/java/current/com/mongodb/AuthenticationMechanism.html">AuthenticationMechanism in MongoDB Java Driver</a>
    */
-  private MongoCredential createCredential(String authenticationType, String username, String database, String password) {
+  private static MongoCredential createCredential(String authenticationType, String username, String database, String password) {
     MongoCredential credential = null;
     if (PLAIN.getMechanismName().equals(authenticationType)) {
       credential = MongoCredential.createPlainCredential(username, database, password.toCharArray());

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.mongodb.store;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class with the collection info returned by MongoStoreMetadataAnalyzer with the information
+ * about a MongoStore collection.
+ *
+ * - Collection document keys
+ */
+public class MongoStoreCollectionMetadata {
+
+    List<String> collectionDocumentKeys = new ArrayList<>();
+
+    /**
+     * Collection document keys present in a given collection at MongoStore
+     */
+    public List<String> getCollectionDocumentKeys() {
+        return collectionDocumentKeys;
+    }
+
+    public void setCollectionDocumentKeys(List<String> collectionDocumentKeys) {
+        this.collectionDocumentKeys = collectionDocumentKeys;
+    }
+}

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class MongoStoreCollectionMetadata {
 
     List<String> collectionDocumentKeys = new ArrayList<>();
+    List<Class<?>> collectionDocumentTypes = new ArrayList<>();
 
     /**
      * Collection document keys present in a given collection at MongoStore
@@ -39,5 +40,16 @@ public class MongoStoreCollectionMetadata {
 
     public void setCollectionDocumentKeys(List<String> collectionDocumentKeys) {
         this.collectionDocumentKeys = collectionDocumentKeys;
+    }
+
+    /**
+     * Collection document types present in a given collection at MongoStore
+     */
+    public List<Class<?>> getCollectionDocumentTypes() {
+        return collectionDocumentTypes;
+    }
+
+    public void setCollectionDocumentTypes(List<Class<?>> collectionDocumentTypes) {
+        this.collectionDocumentTypes = collectionDocumentTypes;
     }
 }

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
@@ -19,37 +19,61 @@ package org.apache.gora.mongodb.store;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Class with the collection info returned by MongoStoreMetadataAnalyzer with the information
  * about a MongoStore collection.
- *
+ * <p>
  * - Collection document keys
  */
 public class MongoStoreCollectionMetadata {
 
-    List<String> collectionDocumentKeys = new ArrayList<>();
-    List<Class<?>> collectionDocumentTypes = new ArrayList<>();
+    private List<String> documentKeys = new ArrayList<>();
+    private List<Class<?>> documentTypes = new ArrayList<>();
 
     /**
      * Collection document keys present in a given collection at MongoStore
      */
-    public List<String> getCollectionDocumentKeys() {
-        return collectionDocumentKeys;
+    public List<String> getDocumentKeys() {
+        return documentKeys;
     }
 
-    public void setCollectionDocumentKeys(List<String> collectionDocumentKeys) {
-        this.collectionDocumentKeys = collectionDocumentKeys;
+    public void setDocumentKeys(List<String> documentKeys) {
+        this.documentKeys = documentKeys;
     }
 
     /**
      * Collection document types present in a given collection at MongoStore
      */
-    public List<Class<?>> getCollectionDocumentTypes() {
-        return collectionDocumentTypes;
+    public List<Class<?>> getDocumentTypes() {
+        return documentTypes;
     }
 
-    public void setCollectionDocumentTypes(List<Class<?>> collectionDocumentTypes) {
-        this.collectionDocumentTypes = collectionDocumentTypes;
+    public void setDocumentTypes(List<Class<?>> documentTypes) {
+        this.documentTypes = documentTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MongoStoreCollectionMetadata that = (MongoStoreCollectionMetadata) o;
+        return documentKeys.equals(that.documentKeys) &&
+                documentTypes.equals(that.documentTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(documentKeys, documentTypes);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", MongoStoreCollectionMetadata.class.getSimpleName() + "[", "]")
+                .add("collectionDocumentKeys=" + documentKeys)
+                .add("collectionDocumentTypes=" + documentTypes)
+                .toString();
     }
 }

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreCollectionMetadata.java
@@ -31,7 +31,7 @@ import java.util.StringJoiner;
 public class MongoStoreCollectionMetadata {
 
     private List<String> documentKeys = new ArrayList<>();
-    private List<Class<?>> documentTypes = new ArrayList<>();
+    private List<String> documentTypes = new ArrayList<>();
 
     /**
      * Collection document keys present in a given collection at MongoStore
@@ -47,11 +47,11 @@ public class MongoStoreCollectionMetadata {
     /**
      * Collection document types present in a given collection at MongoStore
      */
-    public List<Class<?>> getDocumentTypes() {
+    public List<String> getDocumentTypes() {
         return documentTypes;
     }
 
-    public void setDocumentTypes(List<Class<?>> documentTypes) {
+    public void setDocumentTypes(List<String> documentTypes) {
         this.documentTypes = documentTypes;
     }
 

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreMetadataAnalyzer.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreMetadataAnalyzer.java
@@ -57,8 +57,8 @@ public class MongoStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
     public MongoStoreCollectionMetadata getTableInfo(String tableName) {
         MongoStoreCollectionMetadata collectionMetadata = new MongoStoreCollectionMetadata();
         Document document = mongoDatabase.getCollection(tableName).find().first();
-        collectionMetadata.getCollectionDocumentKeys().addAll(document.keySet());
-        collectionMetadata.getCollectionDocumentTypes().addAll(document.values()
+        collectionMetadata.getDocumentKeys().addAll(document.keySet());
+        collectionMetadata.getDocumentTypes().addAll(document.values()
                 .stream().map(Object::getClass).collect(Collectors.toList()));
         return collectionMetadata;
     }

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreMetadataAnalyzer.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreMetadataAnalyzer.java
@@ -21,9 +21,11 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import org.apache.gora.store.impl.DataStoreMetadataAnalyzer;
 import org.apache.gora.util.GoraException;
+import org.bson.Document;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MongoStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
 
@@ -54,7 +56,10 @@ public class MongoStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
     @Override
     public MongoStoreCollectionMetadata getTableInfo(String tableName) {
         MongoStoreCollectionMetadata collectionMetadata = new MongoStoreCollectionMetadata();
-        collectionMetadata.getCollectionDocumentKeys().addAll(mongoDatabase.getCollection(tableName).find().first().keySet());
+        Document document = mongoDatabase.getCollection(tableName).find().first();
+        collectionMetadata.getCollectionDocumentKeys().addAll(document.keySet());
+        collectionMetadata.getCollectionDocumentTypes().addAll(document.values()
+                .stream().map(Object::getClass).collect(Collectors.toList()));
         return collectionMetadata;
     }
 

--- a/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreMetadataAnalyzer.java
+++ b/gora-mongodb/src/main/java/org/apache/gora/mongodb/store/MongoStoreMetadataAnalyzer.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.mongodb.store;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import org.apache.gora.store.impl.DataStoreMetadataAnalyzer;
+import org.apache.gora.util.GoraException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MongoStoreMetadataAnalyzer extends DataStoreMetadataAnalyzer {
+
+    private MongoDatabase mongoDatabase;
+    private MongoClient mongoClient;
+
+    @Override
+    public void initialize() {
+        MongoStoreParameters parameters = MongoStoreParameters.load(properties, getConf());
+        mongoClient = MongoStore.getClient(parameters);
+        mongoDatabase = mongoClient.getDatabase(parameters.getDbname());
+    }
+
+    @Override
+    public String getType() {
+        return "MONGODB";
+    }
+
+    @Override
+    public List<String> getTablesNames() throws GoraException {
+        try {
+            return mongoDatabase.listCollectionNames().into(new ArrayList<>());
+        } catch (Exception e) {
+            throw new GoraException(e);
+        }
+    }
+
+    @Override
+    public MongoStoreCollectionMetadata getTableInfo(String tableName) {
+        MongoStoreCollectionMetadata collectionMetadata = new MongoStoreCollectionMetadata();
+        collectionMetadata.getCollectionDocumentKeys().addAll(mongoDatabase.getCollection(tableName).find().first().keySet());
+        return collectionMetadata;
+    }
+
+    @Override
+    public void close() {
+        if (mongoClient != null) {
+            this.mongoClient.close();
+        }
+    }
+}

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoMappingBuilder.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoMappingBuilder.java
@@ -34,7 +34,7 @@ public class TestMongoMappingBuilder {
     store.setPersistentClass(WebPage.class);
     MongoMappingBuilder<String, WebPage> builder = new MongoMappingBuilder<>(
         store);
-    builder.fromFile("/multimapping.xml");
+    builder.fromInputStream(getClass().getResourceAsStream("/multimapping.xml"));
     MongoMapping mapping = builder.build();
 
     // Check collection name

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStoreMappingFromProperties.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStoreMappingFromProperties.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gora.mongodb.store;
+
+import com.mongodb.ServerAddress;
+import junit.framework.Assert;
+import org.apache.commons.io.IOUtils;
+import org.apache.gora.examples.generated.Employee;
+import org.apache.gora.mongodb.MongoContainer;
+import org.apache.gora.store.DataStoreFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Properties;
+
+/**
+ * Test case for loading mappings from properties
+ */
+public class TestMongoStoreMappingFromProperties {
+    private MongoContainer _container;
+
+    @Before
+    public void setUp() {
+        // Container for MongoStore
+        this._container = new MongoContainer("4.2");
+        _container.start();
+    }
+
+    @Test
+    public void testInitialize() throws IOException {
+        // Simple mapping XML
+        String mappingXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<gora-otd>\n" +
+                "    <class name=\"org.apache.gora.examples.generated.Employee\" keyClass=\"java.lang.String\" document=\"frontier\">\n" +
+                "        <field name=\"name\" docfield=\"name\" type=\"string\"/>\n" +
+                "    </class>\n" +
+                "</gora-otd>";
+
+        // Initiate the MongoDB server on the default port
+        ServerAddress address = _container.getServerAddress();
+        int port = address.getPort();
+        String host = address.getHost();
+
+        Properties prop = DataStoreFactory.createProps();
+
+        // Store Mongo server "host:port" in Hadoop configuration
+        // so that MongoStore will be able to get it latter
+        Configuration conf = new Configuration();
+        conf.set(MongoStoreParameters.PROP_MONGO_SERVERS, host + ":" + port);
+
+        // Set mapping XML property
+        prop.setProperty(MongoStore.XML_MAPPING_DEFINITION, mappingXml);
+        MongoStore<String, Employee> mongoStore =
+                DataStoreFactory.createDataStore(MongoStore.class, String.class, Employee.class, conf, prop);
+        MongoMapping actualMapping = mongoStore.getMapping();
+
+        // Read mapping definition from mappingXml
+        MongoMappingBuilder<String, Employee> builder = new MongoMappingBuilder<>(mongoStore);
+        builder.fromInputStream(IOUtils.toInputStream(mappingXml, (Charset) null));
+        MongoMapping expectedMapping = builder.build();
+
+        Assert.assertEquals(expectedMapping, actualMapping);
+    }
+
+    @After
+    public void tearDown() {
+        _container.stop();
+    }
+}

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStoreMetadataAnalyzer.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStoreMetadataAnalyzer.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gora.mongodb.store;
+
+import com.google.common.collect.Sets;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import org.apache.gora.mongodb.GoraMongodbTestDriver;
+import org.apache.gora.mongodb.MongoContainer;
+import org.apache.gora.store.DataStoreFactory;
+import org.apache.gora.store.DataStoreMetadataFactory;
+import org.apache.gora.store.impl.DataStoreMetadataAnalyzer;
+import org.apache.gora.util.GoraException;
+import org.apache.hadoop.conf.Configuration;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.*;
+
+/**
+ * Test case for MongoStoreMetadataAnalyzer
+ */
+public class TestMongoStoreMetadataAnalyzer extends TestMongoStore {
+    private DataStoreMetadataAnalyzer storeMetadataAnalyzer;
+    private MongoDatabase mongoDatabase;
+
+    @ClassRule
+    public final static MongoContainer container = new MongoContainer("4.2");
+
+    static {
+        setTestDriver(new GoraMongodbTestDriver(container));
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        Properties prop = DataStoreFactory.createProps();
+
+        Configuration conf = testDriver.getConfiguration();
+
+        MongoStoreParameters parameters = MongoStoreParameters.load(prop, conf);
+        MongoClient mongoClient = MongoStore.getClient(parameters);
+        mongoDatabase = mongoClient.getDatabase(parameters.getDbname());
+
+        storeMetadataAnalyzer = DataStoreMetadataFactory.createAnalyzer(conf);
+    }
+
+    @Test
+    public void testGetType() {
+        String actualType = storeMetadataAnalyzer.getType();
+        String expectedType = "MONGODB";
+        Assert.assertEquals(expectedType, actualType);
+    }
+
+    @Test
+    public void testGetTablesNames() throws GoraException {
+        HashSet<String> actualTablesNames = Sets.newHashSet(storeMetadataAnalyzer.getTablesNames());
+        HashSet<String> expectedTablesNames = new HashSet<String>() {
+            {
+                add("frontier");
+                add("webpage");
+            }
+        };
+        Assert.assertEquals(expectedTablesNames, actualTablesNames);
+    }
+
+    @Test
+    public void testGetTableInfo() throws GoraException {
+        mongoDatabase.getCollection("frontier").insertOne(new Document(new HashMap<String, Object>() {
+            {
+                put("name", "Kate");
+                put("dateOfBirth", 830563200);
+                put("ssn", "078051120");
+                put("value", "varchar");
+                put("salary", 70000);
+                put("boss", "");
+                put("webpage", "");
+            }
+        }));
+        MongoStoreCollectionMetadata actualCollectionMetadata = (MongoStoreCollectionMetadata) storeMetadataAnalyzer.getTableInfo("frontier");
+
+        List<String> expectedDocumentKeys = new ArrayList<String>() {
+            {
+                add("name");
+                add("dateOfBirth");
+                add("ssn");
+                add("value");
+                add("salary");
+                add("boss");
+                add("webpage");
+                add("_id");
+            }
+        };
+
+        List<Class<?>> expectedDocumentTypes = new ArrayList<Class<?>>() {
+            {
+                add(String.class);
+                add(Integer.class);
+                add(String.class);
+                add(String.class);
+                add(Integer.class);
+                add(String.class);
+                add(String.class);
+                add(ObjectId.class);
+            }
+        };
+
+        Assert.assertEquals(expectedDocumentKeys.size(), actualCollectionMetadata.getDocumentTypes().size());
+        Assert.assertTrue(expectedDocumentKeys.containsAll(actualCollectionMetadata.getDocumentKeys()));
+
+        Assert.assertEquals(expectedDocumentTypes.size(), actualCollectionMetadata.getDocumentTypes().size());
+        Assert.assertTrue(expectedDocumentTypes.containsAll(actualCollectionMetadata.getDocumentTypes()));
+    }
+}

--- a/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStoreMetadataAnalyzer.java
+++ b/gora-mongodb/src/test/java/org/apache/gora/mongodb/store/TestMongoStoreMetadataAnalyzer.java
@@ -89,7 +89,7 @@ public class TestMongoStoreMetadataAnalyzer extends TestMongoStore {
         mongoDatabase.getCollection("frontier").insertOne(new Document(new HashMap<String, Object>() {
             {
                 put("name", "Kate");
-                put("dateOfBirth", 830563200);
+                put("dateOfBirth", 830563200L);
                 put("ssn", "078051120");
                 put("value", "varchar");
                 put("salary", 70000);
@@ -112,16 +112,16 @@ public class TestMongoStoreMetadataAnalyzer extends TestMongoStore {
             }
         };
 
-        List<Class<?>> expectedDocumentTypes = new ArrayList<Class<?>>() {
+        List<String> expectedDocumentTypes = new ArrayList<String>() {
             {
-                add(String.class);
-                add(Integer.class);
-                add(String.class);
-                add(String.class);
-                add(Integer.class);
-                add(String.class);
-                add(String.class);
-                add(ObjectId.class);
+                add("OBJECT_ID");
+                add("STRING");
+                add("STRING");
+                add("INT64");
+                add("STRING");
+                add("INT32");
+                add("STRING");
+                add("STRING");
             }
         };
 


### PR DESCRIPTION
Since MongoDB has collections instead of tables and these collections do not necessarily have a schema, I decided to use random collection document's key set.