### PR TITLE
GORA-674: upgrade testcontainers to 1.15.2

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -23,7 +23,7 @@ on:
       - master
 
 env:
-  MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version --no-transfer-progress"
+  MAVEN_CLI_OPTS: "--batch-mode --errors --show-version --no-transfer-progress"
 
 jobs:
   build:
@@ -49,7 +49,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build
-        run: mvn $MAVEN_CLI_OPTS -DskipTests clean install
+        run: mvn $MAVEN_CLI_OPTS --fail-at-end -DskipTests clean install
 
       - name: Test
         run: mvn $MAVEN_CLI_OPTS -Dmaven.test.failure.ignore=true verify

--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -52,9 +52,10 @@ jobs:
         run: mvn $MAVEN_CLI_OPTS --fail-at-end -DskipTests clean install
 
       - name: Test
-        run: mvn $MAVEN_CLI_OPTS -Dmaven.test.failure.ignore=true verify
+        run: mvn $MAVEN_CLI_OPTS --fail-at-end verify
 
       - name: Publish Test Results
+        if: ${{ always() }}
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -32,7 +32,17 @@ jobs:
       matrix:
         java: [ '1.8' ]
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Maven caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
@@ -42,4 +52,11 @@ jobs:
         run: mvn $MAVEN_CLI_OPTS -DskipTests clean install
 
       - name: Test
-        run: mvn $MAVEN_CLI_OPTS verify
+        run: mvn $MAVEN_CLI_OPTS -Dmaven.test.failure.ignore=true verify
+
+      - name: Publish Test Results
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: Test Report (${{ matrix.java }})
+          report_paths: '**/*-reports/TEST-*.xml'

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -23,7 +23,7 @@ on:
       - master
 
 env:
-  MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version --no-transfer-progress"
+  MAVEN_CLI_OPTS: "--batch-mode --errors --show-version --no-transfer-progress"
 
 jobs:
   build:
@@ -49,7 +49,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build
-        run: mvn $MAVEN_CLI_OPTS -DskipTests clean install
+        run: mvn $MAVEN_CLI_OPTS --fail-at-end -DskipTests clean install
 
       - name: Test
         run: mvn $MAVEN_CLI_OPTS -Dmaven.test.failure.ignore=true verify

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -52,9 +52,10 @@ jobs:
         run: mvn $MAVEN_CLI_OPTS --fail-at-end -DskipTests clean install
 
       - name: Test
-        run: mvn $MAVEN_CLI_OPTS -Dmaven.test.failure.ignore=true verify
+        run: mvn $MAVEN_CLI_OPTS --fail-at-end verify
 
       - name: Publish Test Results
+        if: ${{ always() }}
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -32,7 +32,17 @@ jobs:
       matrix:
         java: [ '1.8' ]
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Maven caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
@@ -42,4 +52,11 @@ jobs:
         run: mvn $MAVEN_CLI_OPTS -DskipTests clean install
 
       - name: Test
-        run: mvn $MAVEN_CLI_OPTS verify
+        run: mvn $MAVEN_CLI_OPTS -Dmaven.test.failure.ignore=true verify
+
+      - name: Publish Test Results
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: Test Report (${{ matrix.java }})
+          report_paths: '**/*-reports/TEST-*.xml'

--- a/gora-couchdb/pom.xml
+++ b/gora-couchdb/pom.xml
@@ -126,6 +126,10 @@
       <groupId>org.ektorp</groupId>
       <artifactId>org.ektorp</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/gora-couchdb/src/main/java/org/apache/gora/couchdb/util/CouchDBObjectMapperFactory.java
+++ b/gora-couchdb/src/main/java/org/apache/gora/couchdb/util/CouchDBObjectMapperFactory.java
@@ -65,7 +65,7 @@ public class CouchDBObjectMapperFactory implements ObjectMapperFactory {
    */
   private void applyDefaultConfiguration(ObjectMapper om) {
     om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, this.writeDatesAsTimestamps);
-    om.getSerializationConfig().withSerializationInclusion(JsonInclude.Include.NON_NULL);
+    om.setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1807,6 +1807,13 @@
         <artifactId>org.ektorp</artifactId>
         <version>${couchdb.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.12.1</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
 
       <!-- Testing Dependencies -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -884,7 +884,7 @@
 
     <!-- Testing Dependencies -->
     <junit.version>4.10</junit.version>
-    <test.container.version>1.14.3</test.container.version>
+    <testcontainers.version>1.15.2</testcontainers.version>
 
     <!-- gora-benchmark and version dependencies -->
     <site.ycsb.version>0.17.0</site.ycsb.version>
@@ -1830,7 +1830,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>${test.container.version}</version>
+        <version>${testcontainers.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
* As described on testcontainers/testcontainers-java#3574, we need to upgrade to **testcontainers 1.15.2** in order for tests to run on recent Docker runtimes
>    Ok, "filter by image name" query parameter in /images/json got removed on Docker's API.
>    Although the query param was deprecated (I wish we could run Docker in a strict API mode - will explore)
>    Sorry for this. We will release a hotfix ASAP. Meanwhile, consider pre-pulling testcontainers/ryuk:0.3.0 and alpine:3.5

* Upgrade Jackson dependency of `gora-couchdb` module because it depends on **outdated (and unsecured)** release + **trigger NoSuchMethodError** with new testcontainers 1.15.2 (see testcontainers/testcontainers-java#3937). Import `jackson-bom` 2.12.1 in dependency management of main `pom.xml`

* Also update Github Actions (`.github/workflows/*`) to avoid failing build in test of test failures (use `scacap/action-surefire-report` in order to collect failed tests cases)
