### PR TITLE
GORA-651: Upgrade OrientDB to the latest version 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
     <hazelcast.jet.version>3.1</hazelcast.jet.version>
 
     <!-- OrientDB Dependencies -->
-    <orientdb.version>2.2.22</orientdb.version>
+    <orientdb.version>3.2.2</orientdb.version>
     <orientqb.version>0.2.0</orientqb.version>
 
     <!-- RethinkDB Dependencies -->


### PR DESCRIPTION
**Issue Link:**  https://issues.apache.org/jira/browse/GORA-651

I have updated upgraded the version of OrientDB to 3.2.2
All tests are passing locally.  Maybe it could on the upstream.

cc @djkevincr 