### PR TITLE
GORA-630 Move hadoop-common dependencies from gora-hive pom to gora parent pom

### DIFF
--- a/gora-hive/pom.xml
+++ b/gora-hive/pom.xml
@@ -157,20 +157,6 @@
       <artifactId>hadoop-minicluster</artifactId>
     </dependency>
 
-    <!-- 2.6 version of hadoop-common is defined only for gora-hive
-    as it creates some backward compatibility issues by defining in parent-->
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hadoop-common.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>jdk.tools</groupId>
-          <artifactId>jdk.tools</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
     <!-- Hive Dependencies -->
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1850,6 +1850,20 @@
         </exclusions>
       </dependency>
 
+      <!-- 2.6 version of hadoop-common is defined only for gora-hive
+      as it creates some backward compatibility issues by defining in parent-->
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <version>${hadoop-common.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>


### PR DESCRIPTION
Issue Link: https://issues.apache.org/jira/browse/GORA-630 

 Move hadoop-common dependencies from gora-hive pom to gora parent pom as recommended on the ticket  