### PR TITLE
Refactor bad smells:

### DIFF
--- a/gora-core/src/main/java/org/apache/gora/memory/store/MemStore.java
+++ b/gora-core/src/main/java/org/apache/gora/memory/store/MemStore.java
@@ -133,7 +133,7 @@ public class MemStore<K, T extends PersistentBase> extends DataStoreBase<K, T> {
               excludedFields.add(field);
             }
           }
-          T newClonedObj = getPersistent(result.get(),excludedFields.toArray(new String[excludedFields.size()]));
+          T newClonedObj = getPersistent(result.get(),excludedFields.toArray(new String[0]));
           if (delete(result.getKey())) {
             put(result.getKey(),newClonedObj);
             deletedRows++;

--- a/gora-core/src/main/java/org/apache/gora/util/StringUtils.java
+++ b/gora-core/src/main/java/org/apache/gora/util/StringUtils.java
@@ -42,7 +42,7 @@ public class StringUtils {
     Collections.addAll(set, arr1);
     Collections.addAll(set, arr2);
 
-    return set.toArray(new String[set.size()]);
+    return set.toArray(new String[0]);
   }
 
   public static String join(List<String> strs) {

--- a/gora-jcache/src/main/java/org/apache/gora/jcache/store/JCacheStore.java
+++ b/gora-jcache/src/main/java/org/apache/gora/jcache/store/JCacheStore.java
@@ -325,7 +325,7 @@ public class JCacheStore<K, T extends PersistentBase> extends DataStoreBase<K, T
             }
           }
           T newClonedObj = getPersistent(result.get(),
-                  excludedFields.toArray(new String[excludedFields.size()]));
+                  excludedFields.toArray(new String[0]));
           if (delete(result.getKey())) {
             put(result.getKey(), newClonedObj);
             deletedRows++;

--- a/gora-lucene/src/main/java/org/apache/gora/lucene/store/LuceneStore.java
+++ b/gora-lucene/src/main/java/org/apache/gora/lucene/store/LuceneStore.java
@@ -405,7 +405,7 @@ public class LuceneStore<K, T extends PersistentBase>
   public T newInstance(Document doc, String[] fields) throws IOException {
     T persistent = newPersistent();
     if (fields == null) {
-      fields = fieldMap.keySet().toArray(new String[fieldMap.size()]);
+      fields = fieldMap.keySet().toArray(new String[0]);
     }
     String pk = mapping.getPrimaryKey();
 

--- a/gora-maven-plugin/src/main/java/org/apache/gora/maven/plugin/AbstractGoraMojo.java
+++ b/gora-maven-plugin/src/main/java/org/apache/gora/maven/plugin/AbstractGoraMojo.java
@@ -89,7 +89,7 @@ public abstract class AbstractGoraMojo extends AbstractMojo {
     }
     if (!changedFiles.isEmpty()) {
       try {
-        File[] schemaFile = changedFiles.toArray(new File[changedFiles.size()]);
+        File[] schemaFile = changedFiles.toArray(new File[0]);
         GoraCompiler.compileSchema(schemaFile, outputDirectory);
       } catch (SchemaParseException e) {
         if (e.getCause() != null && e.getCause() instanceof JsonParseException) {

--- a/gora-orientdb/src/main/java/org/apache/gora/orientdb/store/OrientDBMapping.java
+++ b/gora-orientdb/src/main/java/org/apache/gora/orientdb/store/OrientDBMapping.java
@@ -117,7 +117,7 @@ public class OrientDBMapping {
    * @return array of fields in string.
    */
   public String[] getDocumentFields() {
-    return documentToClass.keySet().toArray(new String[documentToClass.keySet().size()]);
+    return documentToClass.keySet().toArray(new String[0]);
   }
 
   /**

--- a/gora-rethinkdb/src/main/java/org/apache/gora/rethinkdb/store/RethinkDBMapping.java
+++ b/gora-rethinkdb/src/main/java/org/apache/gora/rethinkdb/store/RethinkDBMapping.java
@@ -77,7 +77,7 @@ public class RethinkDBMapping {
   }
 
   public String[] getDocumentFields() {
-    return documentToClass.keySet().toArray(new String[documentToClass.keySet().size()]);
+    return documentToClass.keySet().toArray(new String[0]);
   }
 
   public String getDocumentField(String field) {

--- a/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
+++ b/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
@@ -154,9 +154,17 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
 
   private SolrMapping mapping;
 
-  private String SolrClientUrl, solrConfig, solrSchema, solrJServerImpl;
+  private String SolrClientUrl;
 
-  private SolrClient server, adminServer;
+  private String solrConfig;
+
+  private String solrSchema;
+
+  private String solrJServerImpl;
+
+  private SolrClient server;
+
+  private SolrClient adminServer;
 
   private boolean serverUserAuth;
 
@@ -579,7 +587,7 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
   public T newInstance(SolrDocument doc, String[] fields) throws IOException {
     T persistent = newPersistent();
     if (fields == null) {
-      fields = fieldMap.keySet().toArray(new String[fieldMap.size()]);
+      fields = fieldMap.keySet().toArray(new String[0]);
     }
     String pk = mapping.getPrimaryKey();
     for (String f : fields) {

--- a/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
+++ b/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
@@ -156,8 +156,6 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
 
   private String SolrClientUrl, solrConfig, solrSchema, solrJServerImpl;
 
-
-
   private SolrClient server, adminServer;
 
   private boolean serverUserAuth;

--- a/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
+++ b/gora-solr/src/main/java/org/apache/gora/solr/store/SolrStore.java
@@ -154,17 +154,11 @@ public class SolrStore<K, T extends PersistentBase> extends DataStoreBase<K, T> 
 
   private SolrMapping mapping;
 
-  private String SolrClientUrl;
+  private String SolrClientUrl, solrConfig, solrSchema, solrJServerImpl;
 
-  private String solrConfig;
 
-  private String solrSchema;
 
-  private String solrJServerImpl;
-
-  private SolrClient server;
-
-  private SolrClient adminServer;
+  private SolrClient server, adminServer;
 
   private boolean serverUserAuth;
 


### PR DESCRIPTION
- ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.