### PR TITLE
test: make hive.store.TestHiveStore.testAutoCreateSchema deterministic

### DIFF
--- a/gora-hive/src/test/java/org/apache/gora/hive/store/TestHiveStore.java
+++ b/gora-hive/src/test/java/org/apache/gora/hive/store/TestHiveStore.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.avro.util.Utf8;
 import org.apache.gora.examples.generated.Employee;
 import org.apache.gora.examples.generated.Metadata;
@@ -53,7 +54,35 @@ public class TestHiveStore extends DataStoreTestBase {
 
   @Override
   public void assertSchemaExists(String schemaName) throws Exception {
-    assertTrue(employeeStore.schemaExists());
+    if ("Employee".equals(schemaName)) {
+      assertTrue(employeeStore.schemaExists());
+      return;
+    }
+    // Include WebPage because base tests call assertSchemaExists("WebPage") in DataStoreTestBase#testTruncateSchema.
+    if ("WebPage".equals(schemaName)) {
+      assertTrue(webPageStore.schemaExists());
+      return;
+    }
+    throw new AssertionError("unsupported schema name: " + schemaName);
+  }
+
+  @Override
+  public void assertAutoCreateSchema() throws Exception {
+    // Poll briefly for Hive metastore visibility only in the auto-create scenario.
+    final long timeoutNanos = TimeUnit.SECONDS.toNanos(5);
+    final long sleepMillis = 100L;
+    long deadline = System.nanoTime() + timeoutNanos;
+    employeeStore.flush();
+    while (System.nanoTime() < deadline) {
+      if (employeeStore.schemaExists()) {
+        assertSchemaExists(((HiveStore<String, Employee>) employeeStore).getSchemaName());
+        return;
+      }
+      TimeUnit.MILLISECONDS.sleep(sleepMillis);
+      employeeStore.flush();
+    }
+    // If still not visible by timeout, fail via the original assertion.
+    assertSchemaExists(((HiveStore<String, Employee>) employeeStore).getSchemaName());
   }
 
   @Override


### PR DESCRIPTION
Title: `test: make org.apache.gora.hive.store.TestHiveStore deterministic`

**Summary**
- Type: timing-safe assertion (metastore visibility)
- Scope: test-only; no production changes
- Module: `gora-hive`
- Test: `org.apache.gora.hive.store.TestHiveStore#testAutoCreateSchema`

**Root Cause**
After auto-creating the table, Hive metastore visibility may lag briefly. A direct `schemaExists()` check immediately after the first write can observe stale metadata.

**Fix**
- Move the wait-for-visibility logic into `assertAutoCreateSchema` only. Poll up to 5 seconds (100 ms interval) with `flush()` between attempts until `schemaExists()` is observed, then assert. The timeout balances reliability and runtime overhead.
- Keep `assertSchemaExists` as a direct existence check and handle both `Employee` and `WebPage` schema names (base tests call `assertSchemaExists("WebPage")` in `DataStoreTestBase#testTruncateSchema`).
- Resolve the schema name via `employeeStore.getSchemaName()` to remain robust to mapping changes.

**Validation**
- Local: executed `mvn -pl gora-hive -Dtest=org.apache.gora.hive.store.TestHiveStore#testAutoCreateSchema test`
- Scope: test-only changes; no production impact

**Risk**
Low. Adds a bounded wait in a single test path; preserves validation semantics.